### PR TITLE
Added method for retrieving genomes in legacy format

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN mkdir -p /kb/module && \
     cd /kb/module && \
     git clone https://github.com/kbase/workspace_deluxe && \
     cd workspace_deluxe && \
-    git checkout b617106 && \
+    git checkout 837ad4c && \
     rm -rf /kb/deployment/lib/biokbase/workspace && \
     cp -vr lib/biokbase/workspace /kb/deployment/lib/biokbase/workspace
 

--- a/GenomeAnnotationAPI.spec
+++ b/GenomeAnnotationAPI.spec
@@ -634,11 +634,10 @@ module GenomeAnnotationAPI {
 
     /*
 
-
     */
     typedef structure {
         string ref;
-        list <string> included;
+        list <int> included_feature_position_index;
         list <string> ref_path_to_genome;
     } LegacyGenomeSelector;
 
@@ -646,12 +645,17 @@ module GenomeAnnotationAPI {
 
     typedef structure {
         list <LegacyGenomeSelector> genomes;
+
+        list <string> included_fields;
+        list <string> included_feature_fields;
+
         boolean ignore_errors;
         boolean no_data;
+        boolean no_metadata;
     } GetLegacyGenomeParams;
 
 
-    /* todo: import Genome type and use it here */
+    /* */
     typedef structure {
         KBaseGenomes.Genome data;
 
@@ -666,17 +670,23 @@ module GenomeAnnotationAPI {
         Workspace.timestamp created;
         Workspace.epoch epoch;
 
+        list<string> refs;
+        mapping<Workspace.id_type, list<Workspace.extracted_id>> extracted_ids;
+
         string handle_error;
         string handle_stacktrace;
     } LegacyGenomeData;
+
 
     typedef structure {
         list<LegacyGenomeData> genomes;
     } LegacyGenomeDataSet;
 
-
+    /* A reasonably simple wrapper on get_objects2, but with Genome specific
+        filters instead of arbitrary get subdata included paths.
+    */
     funcdef get_legacy_genome(GetLegacyGenomeParams params)
-                returns (LegacyGenomeData data) authentication required;
+                returns (LegacyGenomeData data) authentication optional;
 
 
 
@@ -700,7 +710,7 @@ module GenomeAnnotationAPI {
     } SaveLegacyGenomeResult;
 
     funcdef save_one_legacy_genome(SaveLegacyGenomeParams params)
-                returns (SaveLegacyGenomeResult result) authentication required;
+                returns (SaveLegacyGenomeResult result) authentication optional;
 
 
 };

--- a/GenomeAnnotationAPI.spec
+++ b/GenomeAnnotationAPI.spec
@@ -2,6 +2,10 @@
 A KBase module: GenomeAnnotationAPI
 */
 
+#include <workspace.spec>
+#include <KBaseGenomes.spec>
+
+
 module GenomeAnnotationAPI {
     typedef string ObjectReference;
 
@@ -625,4 +629,78 @@ module GenomeAnnotationAPI {
      * of large eukaryotic datasets. It may lead to out-of-memory errors.
      */
     funcdef get_combined_data(GetCombinedDataParams params) returns (GenomeAnnotation_data) authentication required;
+
+
+
+    /*
+
+
+    */
+    typedef structure {
+        string ref;
+        list <string> included;
+        list <string> ref_path_to_genome;
+    } LegacyGenomeSelector;
+
+
+
+    typedef structure {
+        list <LegacyGenomeSelector> genomes;
+        boolean ignore_errors;
+        boolean no_data;
+    } GetLegacyGenomeParams;
+
+
+    /* todo: import Genome type and use it here */
+    typedef structure {
+        KBaseGenomes.Genome data;
+
+        Workspace.object_info info;
+        list<Workspace.ProvenanceAction> provenance;
+
+        string creator;
+        string orig_wsid;
+        string copied;
+        boolean copy_source_inaccessible;
+
+        Workspace.timestamp created;
+        Workspace.epoch epoch;
+
+        string handle_error;
+        string handle_stacktrace;
+    } LegacyGenomeData;
+
+    typedef structure {
+        list<LegacyGenomeData> genomes;
+    } LegacyGenomeDataSet;
+
+
+    funcdef get_legacy_genome(GetLegacyGenomeParams params)
+                returns (LegacyGenomeData data) authentication required;
+
+
+
+    typedef structure {
+
+        KBaseGenomes.Genome data;
+
+        boolean hidden;
+        list<Workspace.ProvenanceAction> provenance;
+
+    } LegacyGenomeSaveData;
+
+    typedef structure {
+        string workspace;
+        string name;
+        list <LegacyGenomeSaveData> genomes;
+    } SaveLegacyGenomeParams;
+
+    typedef structure {
+        list <Workspace.object_info> info;
+    } SaveLegacyGenomeResult;
+
+    funcdef save_one_legacy_genome(SaveLegacyGenomeParams params)
+                returns (SaveLegacyGenomeResult result) authentication required;
+
+
 };

--- a/KBaseGenomes.spec
+++ b/KBaseGenomes.spec
@@ -1,0 +1,706 @@
+/*
+@author chenry,kkeller
+*/
+module KBaseGenomes {
+    /*
+    	Reference to a ContigSet object containing the contigs for this genome in the workspace
+		@id ws KBaseGenomes.ContigSet
+	*/
+    typedef string ContigSet_ref;
+    /*
+		Reference to a ProteinSet object containing the proteins for this genome in the workspace
+		@id ws KBaseGenomes.ProteinSet
+	*/
+    typedef string ProteinSet_ref;
+    /*
+		Reference to a TranscriptSet object containing the transcripts for this genome in the workspace
+		@id ws KBaseGenomes.TranscriptSet
+	*/
+    typedef string TranscriptSet_ref;
+    /*
+		Reference to a Feature object of a genome in the workspace
+		@id subws KBaseGenomes.Genome.features.[*].id
+	*/
+    typedef string Feature_ref;
+    /*
+		Reference to a Genome object in the workspace
+		@id ws KBaseGenomes.Genome KBaseGenomeAnnotations.GenomeAnnotation
+	*/
+    typedef string Genome_ref;
+    /*
+		Reference to an Assembly object in the workspace
+		@id ws KBaseGenomeAnnotations.Assembly
+	*/
+    typedef string Assembly_ref;
+    /*
+		Reference to a Pangenome object in the workspace
+		@id ws KBaseGenomes.Pangenome
+	*/
+    typedef string Pangenome_ref;
+    /*
+		Reference to a Proteome Comparison object in the workspace
+		@id ws GenomeComparison.ProteomeComparison
+	*/
+    typedef string Protcomp_ref;
+    /*
+		Reference to a source_id
+		@id external
+	*/
+    typedef string source_id;
+    /*
+		KBase genome ID
+		@id kb
+	*/
+    typedef string Genome_id;
+    /*
+		KBase Reaction ID
+		@id external
+	*/
+	typedef string Reaction_id;
+    /*
+		KBase Feature ID
+		@id external
+	*/
+	typedef string Feature_id;
+    /*
+		KBase ProteinSet ID
+		@id kb
+	*/
+    typedef string ProteinSet_id;
+	/*
+		ProbabilisticAnnotation ID
+		@id kb
+	*/
+	typedef string ProbabilisticAnnotation_id;
+	/*
+		Genome protein ID
+		@id external
+	*/
+    typedef string Protein_id;
+    /*
+		Reference to an individual contig in a ContigSet object
+		@id subws KBase.ContigSet.contigs.[*].id
+	*/
+    typedef string Contig_ref;
+    /*
+		ContigSet contig ID
+		@id external
+	*/
+    typedef string Contig_id;
+    /*
+		KBase contig set ID
+		@id kb
+	*/
+    typedef string ContigSet_id;
+
+    /*
+		Reference to a reads file in shock
+		@id shock
+	*/
+    typedef string Reads_ref;
+    /*
+		Reference to a fasta file in shock
+		@id shock
+	*/
+    typedef string Fasta_ref;
+    
+    typedef string Feature_type;
+    typedef int Bool;
+    
+    /* Type spec for a "Contig" subobject in the "ContigSet" object
+
+		Contig_id id - ID of contig in contigset
+		string md5 - unique hash of contig sequence
+		string sequence - sequence of the contig
+		string description - Description of the contig (e.g. everything after the ID in a FASTA file)
+
+		@optional length md5 genetic_code cell_compartment replicon_geometry replicon_type name description complete
+	*/
+	typedef structure {
+		Contig_id id;
+		int length;
+		string md5;
+		string sequence;/*using "sequence" instead of "dna"*/
+		int genetic_code;
+		string cell_compartment;
+		string replicon_type;
+		/* circular / linear */
+		string replicon_geometry;
+		string name;
+		string description;
+		Bool complete;
+    } Contig;
+
+    /* Type spec for the "ContigSet" object
+
+		contigset_id id - unique kbase ID of the contig set
+		string name - name of the contig set
+		string type - type of the contig set (values are: Genome,Transcripts,Environment,Collection)
+		source_id source_id - source ID of the contig set
+		string source - source of the contig set
+		list<Contig> contigs - list of contigs in the contig set
+		reads_ref reads_ref - reference to the shocknode with the rawreads from which contigs were assembled
+		fasta_ref fasta_ref - reference to fasta file from which contig set were read
+
+		@optional name type reads_ref fasta_ref
+    	@metadata ws type as Type
+		@metadata ws source_id as Source ID
+		@metadata ws source as Source
+		@metadata ws name as Name
+		@metadata ws length(contigs) as Number contigs
+	*/
+	typedef structure {
+		ContigSet_id id;
+		string name;
+		string md5;
+		source_id source_id;
+		string source;
+		string type;
+		Reads_ref reads_ref;
+		Fasta_ref fasta_ref;
+		list<Contig> contigs;
+    } ContigSet;
+   
+    /*
+		Type of a genome feature with possible values peg, rna
+	*/
+    typedef string feature_type;
+    /* A region of DNA is maintained as a tuple of four components:
+
+		the contig
+		the beginning position (from 1)
+		the strand
+		the length
+
+	   We often speak of "a region".  By "location", we mean a sequence
+	   of regions from the same genome (perhaps from distinct contigs).
+        */
+    typedef tuple<Contig_id contig_id,int begin, string strand,int length> region_of_dna;
+    /*
+		a "location" refers to a list of regions of DNA on contigs
+    */
+    typedef list<region_of_dna> location;
+    
+    /*
+	Structure for a publication (from ER API)
+	also want to capture authors, journal name (not in ER)
+    */
+    typedef tuple<int id, string source_db, string article_title, string link, string pubdate, string authors, string journal_name> publication;
+
+    /*
+	Structure for subsystem data (from CDMI API)
+
+    */
+    typedef tuple<string subsystem, string variant, string role> subsystem_data;
+
+    /*
+	Structure for regulon data (from CDMI API)
+
+    */
+    typedef tuple<string regulon_id, list<Feature_id> regulon_set, list<Feature_id> tfs> regulon_data;
+
+    /*
+	Structure for an atomic regulon (from CDMI API)
+
+    */
+    typedef tuple<string atomic_regulon_id, int atomic_regulon_size> atomic_regulon;
+
+    /*
+	Structure for co-occurring fids (from CDMI API)
+
+    */
+    typedef tuple<Feature_id scored_fid, float score> co_occurring_fid;
+
+    /*
+	Structure for coexpressed fids (from CDMI API)
+
+    */
+    typedef tuple<Feature_id scored_fid, float score> coexpressed_fid;
+    
+   	/*
+	Structure for a protein family
+		@optional query_begin query_end subject_begin subject_end score evalue subject_description release_version
+    */
+    typedef structure {
+		string id;
+		string subject_db;
+		string release_version;
+		string subject_description;
+		int query_begin;
+		int query_end;
+		int subject_begin;
+		int subject_end;
+		float score;
+		float evalue;
+    } ProteinFamily;
+
+	/*
+		a notation by a curator of the genome object
+    */
+    typedef tuple<string comment, string annotator, float annotation_time> annotation;
+	
+	typedef string Analysis_event_id;
+    
+    /*
+    	@optional tool_name execution_time parameters hostname
+    */
+    typedef structure {
+		Analysis_event_id id;
+		string tool_name;
+		float execution_time;
+		list<string> parameters;
+		string hostname;
+    } Analysis_event;
+	
+	/*
+    	@optional weighted_hit_count hit_count existence_priority overlap_rules pyrrolysylprotein truncated_begin truncated_end existence_confidence frameshifted selenoprotein
+    */
+	typedef structure {
+		Bool truncated_begin;
+		Bool truncated_end;
+		/* Is this a real feature? */
+		float existence_confidence;
+
+		Bool frameshifted;
+		Bool selenoprotein;
+		Bool pyrrolysylprotein;
+
+		/*
+		 * List of rules that govern the overlap removal procedure for
+		 * this feature. We don't yet have a strict definition for this but
+		 * the notion is that this will consiste of entries of the form
+		 * +feature-type which will allow overlap with the given feature type;
+		 * -feature-type which will disallow overlap with the given feature type.
+		 */
+		list<string> overlap_rules;
+
+		/*
+		 * The numeric priority of this feature's right to exist. Specialty
+		 * tools will give the features they create a high priority; more generic
+		 * tools will give their features a lower priority. The overlap removal procedure
+		 * will use this priority to determine which of a set of overlapping features
+		 * should be removed.
+		 *
+		 * The intent is that a change of 1 in the priority value represents a factor of 2 in
+		 * preference.
+		 */
+		float existence_priority;
+
+		float hit_count;
+		float weighted_hit_count;
+    } Feature_quality_measure;
+	
+	/*
+		@optional translation_provenance alignment_evidence
+	*/
+	typedef structure {
+		string method;
+		string method_version;
+		string timestamp;
+		tuple<string ontologytranslation_ref, string namespace, string source_term> translation_provenance;
+		list<tuple<int start,int stop, int align_length, float identify>> alignment_evidence;
+	} OntologyEvidence;
+
+	typedef structure {
+		string id;
+		string ontology_ref;
+		list<string> term_lineage;
+		string term_name;
+		list<OntologyEvidence> evidence;
+	} OntologyData;
+
+	/*
+    	Structure for a single feature of a genome
+		
+		Should genome_id contain the genome_id in the Genome object,
+		the workspace id of the Genome object, a genomeref,
+		something else?
+		Should sequence be in separate objects too?
+		We may want to add additional fields for other CDM functions
+		(e.g., atomic regulons, coexpressed fids, co_occurring fids,...)
+
+		@optional orthologs quality feature_creation_event md5 location function ontology_terms protein_translation protein_families subsystems publications subsystem_data aliases annotations regulon_data atomic_regulons coexpressed_fids co_occurring_fids dna_sequence protein_translation_length dna_sequence_length
+    */
+    typedef structure {
+		Feature_id id;
+		list<tuple<Contig_id,int,string,int>> location;
+		string type;
+		string function;
+		mapping<string namespace, mapping<string ontology_term, OntologyData > > ontology_terms;
+		string md5;
+		string protein_translation;
+		string dna_sequence;
+		int protein_translation_length;
+		int dna_sequence_length;
+		list<publication> publications;
+		list<string> subsystems;
+		list<ProteinFamily> protein_families;
+		list<string> aliases;
+		list<tuple<string,float>> orthologs;
+		list<annotation> annotations;
+		list<subsystem_data> subsystem_data;
+		list<regulon_data> regulon_data;
+		list<atomic_regulon> atomic_regulons;
+		list<coexpressed_fid> coexpressed_fids;
+		list<co_occurring_fid> co_occurring_fids;
+		Feature_quality_measure quality;
+		Analysis_event feature_creation_event;
+    } Feature;
+	
+	/*
+    	@optional genome closeness_measure
+    */
+	typedef structure {
+		Genome_id genome;
+		float closeness_measure;
+    } Close_genome;
+
+	/*
+    	@optional frameshift_error_rate sequence_error_rate
+    */
+    typedef structure {
+		float frameshift_error_rate;
+		float sequence_error_rate;
+    } Genome_quality_measure;
+
+    /*
+    	Genome object holds much of the data relevant for a genome in KBase
+	Genome publications should be papers about the genome, not
+	papers about certain features of the genome (which go into the
+	Feature object)
+	Should the Genome object have a list of feature ids? (in
+	addition to having a list of feature_refs)
+	Should the Genome object contain a list of contig_ids too?
+
+    	@optional assembly_ref quality close_genomes analysis_events features source_id source contigs contig_ids publications md5 taxonomy gc_content complete dna_size num_contigs contig_lengths contigset_ref
+    	@metadata ws gc_content as GC content
+    	@metadata ws taxonomy as Taxonomy
+    	@metadata ws md5 as MD5
+    	@metadata ws dna_size as Size
+    	@metadata ws genetic_code as Genetic code
+    	@metadata ws domain as Domain
+		@metadata ws source_id as Source ID
+		@metadata ws source as Source
+		@metadata ws scientific_name as Name
+		@metadata ws length(close_genomes) as Close genomes
+		@metadata ws length(features) as Number features
+		@metadata ws num_contigs as Number contigs
+    */
+    typedef structure {
+		Genome_id id;
+		string scientific_name;
+		string domain;
+		int genetic_code;
+		int dna_size;
+		int num_contigs;
+		list<Contig> contigs;
+		list<int> contig_lengths;
+		list<Contig_id> contig_ids;
+		string source;
+		source_id source_id;
+		string md5;
+		string taxonomy;
+		float gc_content;
+		int complete;
+		list<publication> publications;
+		list<Feature> features;
+		ContigSet_ref contigset_ref;
+		Assembly_ref assembly_ref;
+		
+		Genome_quality_measure quality;
+		list<Close_genome> close_genomes;
+		list <Analysis_event> analysis_events;
+    } Genome;
+    
+	/* Type spec for the "Protein" object
+	
+		Protein_id id - unique external ID of protein
+		string function - annotated function for protein
+		string md5 - md5 hash of protein sequence
+		string sequence - amino acid sequence of protein
+		int length - length of protein
+		list<ProteinFamily> protein_families - families to which the protein belongs
+		list<string> aliases - aliases for the protein
+		list<annotation> annotations - curator annotations on protein
+		list<subsystem_data> subsystem_data;
+		
+		@optional function
+    	@searchable ws_subset id md5 function length aliases
+	*/
+	typedef structure {
+		Protein_id id;
+		string function;
+		string md5;
+		string sequence;
+		int length;
+		list<ProteinFamily> protein_families;
+		list<string> aliases;
+		list<annotation> annotations;
+    } Protein;
+   
+   /* Type spec for the "ProteinSet" object
+
+		proteinset_id id - unique kbase ID of the protein set
+		string name - name of the protein set
+		string type - type of the protein set (values are: Organism,Environment,Collection)
+		source_id source_id - source ID of the protein set
+		string source - source of the protein set
+		list<Protein> proteins - list of proteins in the protein set
+		fasta_ref fasta_ref - reference to fasta file from which contig set were read
+
+		@optional name type fasta_ref
+    	@searchable ws_subset proteins.[*].(id,md5,function,length,aliases) md5 id name source_id source type
+	*/
+	typedef structure {
+		ProteinSet_id id;
+		string name;
+		string md5;
+		source_id source_id;
+		string source;
+		string type;
+		Fasta_ref fasta_ref;
+		list<Protein> proteins;
+    } ProteinSet;
+    
+    /*
+       A function_probability is a (annotation, probability) pair associated with a gene
+       An annotation is a "///"-delimited list of roles that could be associated with that gene.
+    */
+    typedef tuple<string annotation, float probability> function_probability;
+
+    /* Object to carry alternative functions and probabilities for genes in a genome
+
+        probanno_id id - ID of the probabilistic annotation object
+        Genome_ref genome_ref - reference to genome probabilistic annotation was built for
+        mapping<Feature_id, list<function_probability>> roleset_probabilities - mapping of features to list of alternative function_probability objects
+        list<Feature_id> skipped_features - list of features in genome with no probability
+        
+    	@searchable ws_subset id genome_ref skipped_features
+        
+    */
+    typedef structure {
+		ProbabilisticAnnotation_id id;
+		Genome_ref genome_ref;
+		mapping<Feature_id,list<function_probability>> roleset_probabilities;
+		list<Feature_id> skipped_features;
+    } ProbabilisticAnnotation;
+    
+    /* Structure for the "MetagenomeAnnotationOTUFunction" object
+		
+		list<string> reference_genes - list of genes associated with hit
+		string functional_role - annotated function
+		string kbid - kbase ID of OTU function in metagenome
+		int abundance - number of hits with associated role and OTU
+		float confidence - confidence of functional role hit
+		string confidence_type - type of functional role hit
+		
+    	@searchable ws_subset id abundance confidence functional_role
+	*/
+    typedef structure {
+		string id;
+		list<string> reference_genes;
+		string functional_role;
+		int abundance;
+		float confidence;
+    } MetagenomeAnnotationOTUFunction;
+     
+    /* Structure for the "MetagenomeAnnotationOTU" object
+	
+		string name - name of metagenome OTU
+		string kbid - KBase ID of OTU of metagenome object
+		string source_id - ID used for OTU in metagenome source
+		string source - source OTU ID
+		list<MetagenomeAnnotationOTUFunction> functions - list of functions in OTU
+
+    	@searchable ws_subset id name source_id source functions.[*].(id,abundance,confidence,functional_role)
+
+	*/
+    typedef structure {
+    	float ave_confidence;
+		float ave_coverage;
+		string id;
+		string name;
+		string source_id;
+		string source;
+		list<MetagenomeAnnotationOTUFunction> functions;
+    } MetagenomeAnnotationOTU;
+    
+    /* Structure for the "MetagenomeAnnotation" object
+	
+		string type - type of metagenome object
+		string name - name of metagenome object
+		string kbid - KBase ID of metagenome object
+		string source_id - ID used in metagenome source
+		string source - source of metagenome data
+		string confidence_type - type of confidence score
+		list<MetagenomeAnnotationOTU> otus - list of otus in metagenome
+		
+    	@searchable ws_subset type name id source_id source confidence_type otus.[*].(id,name,source_id,source,functions.[*].(id,abundance,confidence,functional_role))
+		@metadata ws type as Type
+		@metadata ws name as Name
+		@metadata ws source_id as Source ID
+		@metadata ws source as Source
+		@metadata ws length(otus) as Number OTUs
+	*/
+    typedef structure {
+		string type;
+		string name;
+		string id;
+		string source_id;
+		string source;
+		string confidence_type;
+		list<MetagenomeAnnotationOTU> otus;
+    } MetagenomeAnnotation;
+    
+    /*
+		Domain - a subobject holding information on a single protein domain
+		string id - numerical ID assigned by KBase
+		string source_id - assession ID from CDD database;
+		string type - type of CDD, possible values are cd, pfam, smart, COG, PRK, CHL
+		string name - name of CDD
+		string description - description of CDD
+    */
+    typedef structure {
+		string id;
+		string source_id;
+		string type;
+		string name;
+		string description;
+    } Domain;
+    
+    /*
+		FeatureDomain - a subobject holding information on how a domain appears in a gene
+		string id - numerical ID assigned by KBase
+		string source_id - assession ID from CDD database;
+		string type - type of CDD, possible values are cd, pfam, smart, COG, PRK, CHL
+		string name - name of CDD
+		string description - description of CDD
+		
+		@optional feature_ref domains
+    */
+    typedef structure {
+		string id;
+		string feature_id;
+		string feature_ref;
+		string function;
+		int feature_length;
+		list<tuple<string domain_ref,int identity,int alignment_length,int mismatches,int gaps,float protein_start,float protein_end,float domain_start,float domain_end,float evalue,float bit_score>> domains;
+    } FeatureDomainData;
+    
+    /*
+    	GenomeDomainData object: this object holds all data regarding protein domains in a genome in KBase
+
+		@optional genome_ref
+    	@searchable ws_subset id genome_id scientific_name genome_ref num_domains num_features
+    */
+    typedef structure {
+    	string id;
+		Genome_id genome_id;
+		string scientific_name;
+		Genome_ref genome_ref;
+		int num_domains;
+		int num_features;
+		
+		list<Domain> domains;
+		list<FeatureDomainData> featuredomains;
+	} GenomeDomainData;
+	
+	/*
+    	OrthologFamily object: this object holds all data for a single ortholog family in a metagenome
+
+    	@optional type function md5 protein_translation
+    */
+	typedef structure {
+    	string id;
+		string type;
+		string function;
+		string md5;
+		string protein_translation;
+		list<tuple<string,float,string>> orthologs;
+	} OrthologFamily;
+	
+	/*
+    	Pangenome object: this object holds all data regarding a pangenome
+
+    	@searchable ws_subset id name
+		@metadata ws type as Type
+		@metadata ws name as Name
+		@metadata ws length(orthologs) as Number orthologs
+		@metadata ws length(genome_refs) as Number genomes
+    */
+    typedef structure {
+    	string id;
+    	string name;
+    	string type;
+    	list<Genome_ref> genome_refs;
+    	list<OrthologFamily> orthologs;
+	} Pangenome;
+	
+	/*
+    	GenomeComparisonGenome object: this object holds information about a genome in a genome comparison
+    */
+    typedef structure {
+		string id;
+		Genome_ref genome_ref;
+		mapping<string genome_id,tuple<int commonfamilies,int commonfunctions> > genome_similarity;
+		string name;
+		string taxonomy;
+		int features;
+		int families;
+		int functions;
+    } GenomeComparisonGenome;
+ 
+    /*
+    	GenomeComparisonFunction object: this object holds information about a genome in a function across all genomes
+    */
+    typedef structure {
+		int core;
+		mapping<string genome_id,list<tuple<Feature_id,int famindex,float score> > > genome_features;
+		string id;
+		list<tuple<Reaction_id, string equation>> reactions;
+		string subsystem;
+		string primclass;
+		string subclass;
+		int number_genomes;
+		float fraction_genomes;
+		float fraction_consistent_families;
+		string most_consistent_family;
+    } GenomeComparisonFunction;
+    
+    /*
+    	GenomeComparisonFamily object: this object holds information about a protein family across a set of genomes
+    */
+    typedef structure {
+		int core;
+		mapping<string genome_id,list< tuple<Feature_id,list<int> funcindecies,float score > > > genome_features;
+		string id;
+		string type;
+		string protein_translation;
+		int number_genomes;
+		float fraction_genomes;
+		float fraction_consistent_annotations;
+		string most_consistent_role;
+    } GenomeComparisonFamily;
+    
+    /*
+    	GenomeComparisonData object: this object holds information about a multigenome comparison
+    	
+    	@optional protcomp_ref pangenome_ref
+    	@metadata ws core_functions as Core functions
+		@metadata ws core_families as Core families
+		@metadata ws name as Name
+		@metadata ws length(genomes) as Number genomes
+    */
+    typedef structure {
+		string id;
+		string name;
+		int core_functions;
+		int core_families;
+		Protcomp_ref protcomp_ref;
+		Pangenome_ref pangenome_ref;
+		list<GenomeComparisonGenome> genomes;
+		list<GenomeComparisonFamily> families;
+		list<GenomeComparisonFunction> functions;
+    } GenomeComparison;
+};
+

--- a/lib/GenomeAnnotationAPI/GenomeAnnotationAPIClient.pm
+++ b/lib/GenomeAnnotationAPI/GenomeAnnotationAPIClient.pm
@@ -88,14 +88,6 @@ sub new
 	    $self->{token} = $token->token;
 	    $self->{client}->{token} = $token->token;
 	}
-        else
-        {
-	    #
-	    # All methods in this module require authentication. In this case, if we
-	    # don't have a token, we can't continue.
-	    #
-	    die "Authentication failed: " . $token->error_message;
-	}
     }
 
     my $ua = $self->{client}->ua;	 
@@ -2771,11 +2763,13 @@ $params is a GenomeAnnotationAPI.GetLegacyGenomeParams
 $data is a GenomeAnnotationAPI.LegacyGenomeData
 GetLegacyGenomeParams is a reference to a hash where the following keys are defined:
 	genomes has a value which is a reference to a list where each element is a GenomeAnnotationAPI.LegacyGenomeSelector
+	included_fields has a value which is a reference to a list where each element is a string
+	included_feature_fields has a value which is a reference to a list where each element is a string
 	ignore_errors has a value which is a GenomeAnnotationAPI.boolean
 	no_data has a value which is a GenomeAnnotationAPI.boolean
 LegacyGenomeSelector is a reference to a hash where the following keys are defined:
 	ref has a value which is a string
-	included has a value which is a reference to a list where each element is a string
+	included_feature_position_index has a value which is a reference to a list where each element is an int
 	ref_path_to_genome has a value which is a reference to a list where each element is a string
 boolean is an int
 LegacyGenomeData is a reference to a hash where the following keys are defined:
@@ -2788,6 +2782,8 @@ LegacyGenomeData is a reference to a hash where the following keys are defined:
 	copy_source_inaccessible has a value which is a GenomeAnnotationAPI.boolean
 	created has a value which is a Workspace.timestamp
 	epoch has a value which is a Workspace.epoch
+	refs has a value which is a reference to a list where each element is a string
+	extracted_ids has a value which is a reference to a hash where the key is a Workspace.id_type and the value is a reference to a list where each element is a Workspace.extracted_id
 	handle_error has a value which is a string
 	handle_stacktrace has a value which is a string
 Genome is a reference to a hash where the following keys are defined:
@@ -3005,6 +3001,8 @@ SubAction is a reference to a hash where the following keys are defined:
 	code_url has a value which is a string
 	commit has a value which is a string
 	endpoint_url has a value which is a string
+id_type is a string
+extracted_id is a string
 
 </pre>
 
@@ -3016,11 +3014,13 @@ $params is a GenomeAnnotationAPI.GetLegacyGenomeParams
 $data is a GenomeAnnotationAPI.LegacyGenomeData
 GetLegacyGenomeParams is a reference to a hash where the following keys are defined:
 	genomes has a value which is a reference to a list where each element is a GenomeAnnotationAPI.LegacyGenomeSelector
+	included_fields has a value which is a reference to a list where each element is a string
+	included_feature_fields has a value which is a reference to a list where each element is a string
 	ignore_errors has a value which is a GenomeAnnotationAPI.boolean
 	no_data has a value which is a GenomeAnnotationAPI.boolean
 LegacyGenomeSelector is a reference to a hash where the following keys are defined:
 	ref has a value which is a string
-	included has a value which is a reference to a list where each element is a string
+	included_feature_position_index has a value which is a reference to a list where each element is an int
 	ref_path_to_genome has a value which is a reference to a list where each element is a string
 boolean is an int
 LegacyGenomeData is a reference to a hash where the following keys are defined:
@@ -3033,6 +3033,8 @@ LegacyGenomeData is a reference to a hash where the following keys are defined:
 	copy_source_inaccessible has a value which is a GenomeAnnotationAPI.boolean
 	created has a value which is a Workspace.timestamp
 	epoch has a value which is a Workspace.epoch
+	refs has a value which is a reference to a list where each element is a string
+	extracted_ids has a value which is a reference to a hash where the key is a Workspace.id_type and the value is a reference to a list where each element is a Workspace.extracted_id
 	handle_error has a value which is a string
 	handle_stacktrace has a value which is a string
 Genome is a reference to a hash where the following keys are defined:
@@ -3250,6 +3252,8 @@ SubAction is a reference to a hash where the following keys are defined:
 	code_url has a value which is a string
 	commit has a value which is a string
 	endpoint_url has a value which is a string
+id_type is a string
+extracted_id is a string
 
 
 =end text
@@ -3266,7 +3270,7 @@ SubAction is a reference to a hash where the following keys are defined:
 {
     my($self, @args) = @_;
 
-# Authentication: required
+# Authentication: optional
 
     if ((my $n = @args) != 1)
     {
@@ -3800,7 +3804,7 @@ usermeta is a reference to a hash where the key is a string and the value is a s
 {
     my($self, @args) = @_;
 
-# Authentication: required
+# Authentication: optional
 
     if ((my $n = @args) != 1)
     {
@@ -5374,7 +5378,7 @@ exclude_summary has a value which is a GenomeAnnotationAPI.boolean
 <pre>
 a reference to a hash where the following keys are defined:
 ref has a value which is a string
-included has a value which is a reference to a list where each element is a string
+included_feature_position_index has a value which is a reference to a list where each element is an int
 ref_path_to_genome has a value which is a reference to a list where each element is a string
 
 </pre>
@@ -5385,7 +5389,7 @@ ref_path_to_genome has a value which is a reference to a list where each element
 
 a reference to a hash where the following keys are defined:
 ref has a value which is a string
-included has a value which is a reference to a list where each element is a string
+included_feature_position_index has a value which is a reference to a list where each element is an int
 ref_path_to_genome has a value which is a reference to a list where each element is a string
 
 
@@ -5408,6 +5412,8 @@ ref_path_to_genome has a value which is a reference to a list where each element
 <pre>
 a reference to a hash where the following keys are defined:
 genomes has a value which is a reference to a list where each element is a GenomeAnnotationAPI.LegacyGenomeSelector
+included_fields has a value which is a reference to a list where each element is a string
+included_feature_fields has a value which is a reference to a list where each element is a string
 ignore_errors has a value which is a GenomeAnnotationAPI.boolean
 no_data has a value which is a GenomeAnnotationAPI.boolean
 
@@ -5419,6 +5425,8 @@ no_data has a value which is a GenomeAnnotationAPI.boolean
 
 a reference to a hash where the following keys are defined:
 genomes has a value which is a reference to a list where each element is a GenomeAnnotationAPI.LegacyGenomeSelector
+included_fields has a value which is a reference to a list where each element is a string
+included_feature_fields has a value which is a reference to a list where each element is a string
 ignore_errors has a value which is a GenomeAnnotationAPI.boolean
 no_data has a value which is a GenomeAnnotationAPI.boolean
 
@@ -5455,6 +5463,8 @@ copied has a value which is a string
 copy_source_inaccessible has a value which is a GenomeAnnotationAPI.boolean
 created has a value which is a Workspace.timestamp
 epoch has a value which is a Workspace.epoch
+refs has a value which is a reference to a list where each element is a string
+extracted_ids has a value which is a reference to a hash where the key is a Workspace.id_type and the value is a reference to a list where each element is a Workspace.extracted_id
 handle_error has a value which is a string
 handle_stacktrace has a value which is a string
 
@@ -5474,6 +5484,8 @@ copied has a value which is a string
 copy_source_inaccessible has a value which is a GenomeAnnotationAPI.boolean
 created has a value which is a Workspace.timestamp
 epoch has a value which is a Workspace.epoch
+refs has a value which is a reference to a list where each element is a string
+extracted_ids has a value which is a reference to a hash where the key is a Workspace.id_type and the value is a reference to a list where each element is a Workspace.extracted_id
 handle_error has a value which is a string
 handle_stacktrace has a value which is a string
 

--- a/lib/GenomeAnnotationAPI/GenomeAnnotationAPIClient.pm
+++ b/lib/GenomeAnnotationAPI/GenomeAnnotationAPIClient.pm
@@ -26,7 +26,7 @@ GenomeAnnotationAPI::GenomeAnnotationAPIClient
 =head1 DESCRIPTION
 
 
-A KBase module: GenomeAnnotationAPI
+
 
 
 =cut
@@ -2754,6 +2754,1094 @@ of large eukaryotic datasets. It may lead to out-of-memory errors.
     }
 }
  
+
+
+=head2 get_legacy_genome
+
+  $data = $obj->get_legacy_genome($params)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$params is a GenomeAnnotationAPI.GetLegacyGenomeParams
+$data is a GenomeAnnotationAPI.LegacyGenomeData
+GetLegacyGenomeParams is a reference to a hash where the following keys are defined:
+	genomes has a value which is a reference to a list where each element is a GenomeAnnotationAPI.LegacyGenomeSelector
+	ignore_errors has a value which is a GenomeAnnotationAPI.boolean
+	no_data has a value which is a GenomeAnnotationAPI.boolean
+LegacyGenomeSelector is a reference to a hash where the following keys are defined:
+	ref has a value which is a string
+	included has a value which is a reference to a list where each element is a string
+	ref_path_to_genome has a value which is a reference to a list where each element is a string
+boolean is an int
+LegacyGenomeData is a reference to a hash where the following keys are defined:
+	data has a value which is a KBaseGenomes.Genome
+	info has a value which is a Workspace.object_info
+	provenance has a value which is a reference to a list where each element is a Workspace.ProvenanceAction
+	creator has a value which is a string
+	orig_wsid has a value which is a string
+	copied has a value which is a string
+	copy_source_inaccessible has a value which is a GenomeAnnotationAPI.boolean
+	created has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
+	handle_error has a value which is a string
+	handle_stacktrace has a value which is a string
+Genome is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Genome_id
+	scientific_name has a value which is a string
+	domain has a value which is a string
+	genetic_code has a value which is an int
+	dna_size has a value which is an int
+	num_contigs has a value which is an int
+	contigs has a value which is a reference to a list where each element is a KBaseGenomes.Contig
+	contig_lengths has a value which is a reference to a list where each element is an int
+	contig_ids has a value which is a reference to a list where each element is a KBaseGenomes.Contig_id
+	source has a value which is a string
+	source_id has a value which is a KBaseGenomes.source_id
+	md5 has a value which is a string
+	taxonomy has a value which is a string
+	gc_content has a value which is a float
+	complete has a value which is an int
+	publications has a value which is a reference to a list where each element is a KBaseGenomes.publication
+	features has a value which is a reference to a list where each element is a KBaseGenomes.Feature
+	contigset_ref has a value which is a KBaseGenomes.ContigSet_ref
+	assembly_ref has a value which is a KBaseGenomes.Assembly_ref
+	quality has a value which is a KBaseGenomes.Genome_quality_measure
+	close_genomes has a value which is a reference to a list where each element is a KBaseGenomes.Close_genome
+	analysis_events has a value which is a reference to a list where each element is a KBaseGenomes.Analysis_event
+Genome_id is a string
+Contig is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Contig_id
+	length has a value which is an int
+	md5 has a value which is a string
+	sequence has a value which is a string
+	genetic_code has a value which is an int
+	cell_compartment has a value which is a string
+	replicon_type has a value which is a string
+	replicon_geometry has a value which is a string
+	name has a value which is a string
+	description has a value which is a string
+	complete has a value which is a KBaseGenomes.Bool
+Contig_id is a string
+Bool is an int
+source_id is a string
+publication is a reference to a list containing 7 items:
+	0: (id) an int
+	1: (source_db) a string
+	2: (article_title) a string
+	3: (link) a string
+	4: (pubdate) a string
+	5: (authors) a string
+	6: (journal_name) a string
+Feature is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Feature_id
+	location has a value which is a reference to a list where each element is a reference to a list containing 4 items:
+		0: a KBaseGenomes.Contig_id
+		1: an int
+		2: a string
+		3: an int
+
+	type has a value which is a string
+	function has a value which is a string
+	ontology_terms has a value which is a reference to a hash where the key is a string and the value is a reference to a hash where the key is a string and the value is a KBaseGenomes.OntologyData
+	md5 has a value which is a string
+	protein_translation has a value which is a string
+	dna_sequence has a value which is a string
+	protein_translation_length has a value which is an int
+	dna_sequence_length has a value which is an int
+	publications has a value which is a reference to a list where each element is a KBaseGenomes.publication
+	subsystems has a value which is a reference to a list where each element is a string
+	protein_families has a value which is a reference to a list where each element is a KBaseGenomes.ProteinFamily
+	aliases has a value which is a reference to a list where each element is a string
+	orthologs has a value which is a reference to a list where each element is a reference to a list containing 2 items:
+		0: a string
+		1: a float
+
+	annotations has a value which is a reference to a list where each element is a KBaseGenomes.annotation
+	subsystem_data has a value which is a reference to a list where each element is a KBaseGenomes.subsystem_data
+	regulon_data has a value which is a reference to a list where each element is a KBaseGenomes.regulon_data
+	atomic_regulons has a value which is a reference to a list where each element is a KBaseGenomes.atomic_regulon
+	coexpressed_fids has a value which is a reference to a list where each element is a KBaseGenomes.coexpressed_fid
+	co_occurring_fids has a value which is a reference to a list where each element is a KBaseGenomes.co_occurring_fid
+	quality has a value which is a KBaseGenomes.Feature_quality_measure
+	feature_creation_event has a value which is a KBaseGenomes.Analysis_event
+Feature_id is a string
+OntologyData is a reference to a hash where the following keys are defined:
+	id has a value which is a string
+	ontology_ref has a value which is a string
+	term_lineage has a value which is a reference to a list where each element is a string
+	term_name has a value which is a string
+	evidence has a value which is a reference to a list where each element is a KBaseGenomes.OntologyEvidence
+OntologyEvidence is a reference to a hash where the following keys are defined:
+	method has a value which is a string
+	method_version has a value which is a string
+	timestamp has a value which is a string
+	translation_provenance has a value which is a reference to a list containing 3 items:
+		0: (ontologytranslation_ref) a string
+		1: (namespace) a string
+		2: (source_term) a string
+
+	alignment_evidence has a value which is a reference to a list where each element is a reference to a list containing 4 items:
+		0: (start) an int
+		1: (stop) an int
+		2: (align_length) an int
+		3: (identify) a float
+
+ProteinFamily is a reference to a hash where the following keys are defined:
+	id has a value which is a string
+	subject_db has a value which is a string
+	release_version has a value which is a string
+	subject_description has a value which is a string
+	query_begin has a value which is an int
+	query_end has a value which is an int
+	subject_begin has a value which is an int
+	subject_end has a value which is an int
+	score has a value which is a float
+	evalue has a value which is a float
+annotation is a reference to a list containing 3 items:
+	0: (comment) a string
+	1: (annotator) a string
+	2: (annotation_time) a float
+subsystem_data is a reference to a list containing 3 items:
+	0: (subsystem) a string
+	1: (variant) a string
+	2: (role) a string
+regulon_data is a reference to a list containing 3 items:
+	0: (regulon_id) a string
+	1: (regulon_set) a reference to a list where each element is a KBaseGenomes.Feature_id
+	2: (tfs) a reference to a list where each element is a KBaseGenomes.Feature_id
+atomic_regulon is a reference to a list containing 2 items:
+	0: (atomic_regulon_id) a string
+	1: (atomic_regulon_size) an int
+coexpressed_fid is a reference to a list containing 2 items:
+	0: (scored_fid) a KBaseGenomes.Feature_id
+	1: (score) a float
+co_occurring_fid is a reference to a list containing 2 items:
+	0: (scored_fid) a KBaseGenomes.Feature_id
+	1: (score) a float
+Feature_quality_measure is a reference to a hash where the following keys are defined:
+	truncated_begin has a value which is a KBaseGenomes.Bool
+	truncated_end has a value which is a KBaseGenomes.Bool
+	existence_confidence has a value which is a float
+	frameshifted has a value which is a KBaseGenomes.Bool
+	selenoprotein has a value which is a KBaseGenomes.Bool
+	pyrrolysylprotein has a value which is a KBaseGenomes.Bool
+	overlap_rules has a value which is a reference to a list where each element is a string
+	existence_priority has a value which is a float
+	hit_count has a value which is a float
+	weighted_hit_count has a value which is a float
+Analysis_event is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Analysis_event_id
+	tool_name has a value which is a string
+	execution_time has a value which is a float
+	parameters has a value which is a reference to a list where each element is a string
+	hostname has a value which is a string
+Analysis_event_id is a string
+ContigSet_ref is a string
+Assembly_ref is a string
+Genome_quality_measure is a reference to a hash where the following keys are defined:
+	frameshift_error_rate has a value which is a float
+	sequence_error_rate has a value which is a float
+Close_genome is a reference to a hash where the following keys are defined:
+	genome has a value which is a KBaseGenomes.Genome_id
+	closeness_measure has a value which is a float
+object_info is a reference to a list containing 11 items:
+	0: (objid) a Workspace.obj_id
+	1: (name) a Workspace.obj_name
+	2: (type) a Workspace.type_string
+	3: (save_date) a Workspace.timestamp
+	4: (version) an int
+	5: (saved_by) a Workspace.username
+	6: (wsid) a Workspace.ws_id
+	7: (workspace) a Workspace.ws_name
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a Workspace.usermeta
+obj_id is an int
+obj_name is a string
+type_string is a string
+timestamp is a string
+username is a string
+ws_id is an int
+ws_name is a string
+usermeta is a reference to a hash where the key is a string and the value is a string
+ProvenanceAction is a reference to a hash where the following keys are defined:
+	time has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
+	caller has a value which is a string
+	service has a value which is a string
+	service_ver has a value which is a string
+	method has a value which is a string
+	method_params has a value which is a reference to a list where each element is an UnspecifiedObject, which can hold any non-null object
+	script has a value which is a string
+	script_ver has a value which is a string
+	script_command_line has a value which is a string
+	input_ws_objects has a value which is a reference to a list where each element is a Workspace.obj_ref
+	resolved_ws_objects has a value which is a reference to a list where each element is a Workspace.obj_ref
+	intermediate_incoming has a value which is a reference to a list where each element is a string
+	intermediate_outgoing has a value which is a reference to a list where each element is a string
+	external_data has a value which is a reference to a list where each element is a Workspace.ExternalDataUnit
+	subactions has a value which is a reference to a list where each element is a Workspace.SubAction
+	custom has a value which is a reference to a hash where the key is a string and the value is a string
+	description has a value which is a string
+epoch is an int
+obj_ref is a string
+ExternalDataUnit is a reference to a hash where the following keys are defined:
+	resource_name has a value which is a string
+	resource_url has a value which is a string
+	resource_version has a value which is a string
+	resource_release_date has a value which is a Workspace.timestamp
+	resource_release_epoch has a value which is a Workspace.epoch
+	data_url has a value which is a string
+	data_id has a value which is a string
+	description has a value which is a string
+SubAction is a reference to a hash where the following keys are defined:
+	name has a value which is a string
+	ver has a value which is a string
+	code_url has a value which is a string
+	commit has a value which is a string
+	endpoint_url has a value which is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+$params is a GenomeAnnotationAPI.GetLegacyGenomeParams
+$data is a GenomeAnnotationAPI.LegacyGenomeData
+GetLegacyGenomeParams is a reference to a hash where the following keys are defined:
+	genomes has a value which is a reference to a list where each element is a GenomeAnnotationAPI.LegacyGenomeSelector
+	ignore_errors has a value which is a GenomeAnnotationAPI.boolean
+	no_data has a value which is a GenomeAnnotationAPI.boolean
+LegacyGenomeSelector is a reference to a hash where the following keys are defined:
+	ref has a value which is a string
+	included has a value which is a reference to a list where each element is a string
+	ref_path_to_genome has a value which is a reference to a list where each element is a string
+boolean is an int
+LegacyGenomeData is a reference to a hash where the following keys are defined:
+	data has a value which is a KBaseGenomes.Genome
+	info has a value which is a Workspace.object_info
+	provenance has a value which is a reference to a list where each element is a Workspace.ProvenanceAction
+	creator has a value which is a string
+	orig_wsid has a value which is a string
+	copied has a value which is a string
+	copy_source_inaccessible has a value which is a GenomeAnnotationAPI.boolean
+	created has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
+	handle_error has a value which is a string
+	handle_stacktrace has a value which is a string
+Genome is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Genome_id
+	scientific_name has a value which is a string
+	domain has a value which is a string
+	genetic_code has a value which is an int
+	dna_size has a value which is an int
+	num_contigs has a value which is an int
+	contigs has a value which is a reference to a list where each element is a KBaseGenomes.Contig
+	contig_lengths has a value which is a reference to a list where each element is an int
+	contig_ids has a value which is a reference to a list where each element is a KBaseGenomes.Contig_id
+	source has a value which is a string
+	source_id has a value which is a KBaseGenomes.source_id
+	md5 has a value which is a string
+	taxonomy has a value which is a string
+	gc_content has a value which is a float
+	complete has a value which is an int
+	publications has a value which is a reference to a list where each element is a KBaseGenomes.publication
+	features has a value which is a reference to a list where each element is a KBaseGenomes.Feature
+	contigset_ref has a value which is a KBaseGenomes.ContigSet_ref
+	assembly_ref has a value which is a KBaseGenomes.Assembly_ref
+	quality has a value which is a KBaseGenomes.Genome_quality_measure
+	close_genomes has a value which is a reference to a list where each element is a KBaseGenomes.Close_genome
+	analysis_events has a value which is a reference to a list where each element is a KBaseGenomes.Analysis_event
+Genome_id is a string
+Contig is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Contig_id
+	length has a value which is an int
+	md5 has a value which is a string
+	sequence has a value which is a string
+	genetic_code has a value which is an int
+	cell_compartment has a value which is a string
+	replicon_type has a value which is a string
+	replicon_geometry has a value which is a string
+	name has a value which is a string
+	description has a value which is a string
+	complete has a value which is a KBaseGenomes.Bool
+Contig_id is a string
+Bool is an int
+source_id is a string
+publication is a reference to a list containing 7 items:
+	0: (id) an int
+	1: (source_db) a string
+	2: (article_title) a string
+	3: (link) a string
+	4: (pubdate) a string
+	5: (authors) a string
+	6: (journal_name) a string
+Feature is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Feature_id
+	location has a value which is a reference to a list where each element is a reference to a list containing 4 items:
+		0: a KBaseGenomes.Contig_id
+		1: an int
+		2: a string
+		3: an int
+
+	type has a value which is a string
+	function has a value which is a string
+	ontology_terms has a value which is a reference to a hash where the key is a string and the value is a reference to a hash where the key is a string and the value is a KBaseGenomes.OntologyData
+	md5 has a value which is a string
+	protein_translation has a value which is a string
+	dna_sequence has a value which is a string
+	protein_translation_length has a value which is an int
+	dna_sequence_length has a value which is an int
+	publications has a value which is a reference to a list where each element is a KBaseGenomes.publication
+	subsystems has a value which is a reference to a list where each element is a string
+	protein_families has a value which is a reference to a list where each element is a KBaseGenomes.ProteinFamily
+	aliases has a value which is a reference to a list where each element is a string
+	orthologs has a value which is a reference to a list where each element is a reference to a list containing 2 items:
+		0: a string
+		1: a float
+
+	annotations has a value which is a reference to a list where each element is a KBaseGenomes.annotation
+	subsystem_data has a value which is a reference to a list where each element is a KBaseGenomes.subsystem_data
+	regulon_data has a value which is a reference to a list where each element is a KBaseGenomes.regulon_data
+	atomic_regulons has a value which is a reference to a list where each element is a KBaseGenomes.atomic_regulon
+	coexpressed_fids has a value which is a reference to a list where each element is a KBaseGenomes.coexpressed_fid
+	co_occurring_fids has a value which is a reference to a list where each element is a KBaseGenomes.co_occurring_fid
+	quality has a value which is a KBaseGenomes.Feature_quality_measure
+	feature_creation_event has a value which is a KBaseGenomes.Analysis_event
+Feature_id is a string
+OntologyData is a reference to a hash where the following keys are defined:
+	id has a value which is a string
+	ontology_ref has a value which is a string
+	term_lineage has a value which is a reference to a list where each element is a string
+	term_name has a value which is a string
+	evidence has a value which is a reference to a list where each element is a KBaseGenomes.OntologyEvidence
+OntologyEvidence is a reference to a hash where the following keys are defined:
+	method has a value which is a string
+	method_version has a value which is a string
+	timestamp has a value which is a string
+	translation_provenance has a value which is a reference to a list containing 3 items:
+		0: (ontologytranslation_ref) a string
+		1: (namespace) a string
+		2: (source_term) a string
+
+	alignment_evidence has a value which is a reference to a list where each element is a reference to a list containing 4 items:
+		0: (start) an int
+		1: (stop) an int
+		2: (align_length) an int
+		3: (identify) a float
+
+ProteinFamily is a reference to a hash where the following keys are defined:
+	id has a value which is a string
+	subject_db has a value which is a string
+	release_version has a value which is a string
+	subject_description has a value which is a string
+	query_begin has a value which is an int
+	query_end has a value which is an int
+	subject_begin has a value which is an int
+	subject_end has a value which is an int
+	score has a value which is a float
+	evalue has a value which is a float
+annotation is a reference to a list containing 3 items:
+	0: (comment) a string
+	1: (annotator) a string
+	2: (annotation_time) a float
+subsystem_data is a reference to a list containing 3 items:
+	0: (subsystem) a string
+	1: (variant) a string
+	2: (role) a string
+regulon_data is a reference to a list containing 3 items:
+	0: (regulon_id) a string
+	1: (regulon_set) a reference to a list where each element is a KBaseGenomes.Feature_id
+	2: (tfs) a reference to a list where each element is a KBaseGenomes.Feature_id
+atomic_regulon is a reference to a list containing 2 items:
+	0: (atomic_regulon_id) a string
+	1: (atomic_regulon_size) an int
+coexpressed_fid is a reference to a list containing 2 items:
+	0: (scored_fid) a KBaseGenomes.Feature_id
+	1: (score) a float
+co_occurring_fid is a reference to a list containing 2 items:
+	0: (scored_fid) a KBaseGenomes.Feature_id
+	1: (score) a float
+Feature_quality_measure is a reference to a hash where the following keys are defined:
+	truncated_begin has a value which is a KBaseGenomes.Bool
+	truncated_end has a value which is a KBaseGenomes.Bool
+	existence_confidence has a value which is a float
+	frameshifted has a value which is a KBaseGenomes.Bool
+	selenoprotein has a value which is a KBaseGenomes.Bool
+	pyrrolysylprotein has a value which is a KBaseGenomes.Bool
+	overlap_rules has a value which is a reference to a list where each element is a string
+	existence_priority has a value which is a float
+	hit_count has a value which is a float
+	weighted_hit_count has a value which is a float
+Analysis_event is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Analysis_event_id
+	tool_name has a value which is a string
+	execution_time has a value which is a float
+	parameters has a value which is a reference to a list where each element is a string
+	hostname has a value which is a string
+Analysis_event_id is a string
+ContigSet_ref is a string
+Assembly_ref is a string
+Genome_quality_measure is a reference to a hash where the following keys are defined:
+	frameshift_error_rate has a value which is a float
+	sequence_error_rate has a value which is a float
+Close_genome is a reference to a hash where the following keys are defined:
+	genome has a value which is a KBaseGenomes.Genome_id
+	closeness_measure has a value which is a float
+object_info is a reference to a list containing 11 items:
+	0: (objid) a Workspace.obj_id
+	1: (name) a Workspace.obj_name
+	2: (type) a Workspace.type_string
+	3: (save_date) a Workspace.timestamp
+	4: (version) an int
+	5: (saved_by) a Workspace.username
+	6: (wsid) a Workspace.ws_id
+	7: (workspace) a Workspace.ws_name
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a Workspace.usermeta
+obj_id is an int
+obj_name is a string
+type_string is a string
+timestamp is a string
+username is a string
+ws_id is an int
+ws_name is a string
+usermeta is a reference to a hash where the key is a string and the value is a string
+ProvenanceAction is a reference to a hash where the following keys are defined:
+	time has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
+	caller has a value which is a string
+	service has a value which is a string
+	service_ver has a value which is a string
+	method has a value which is a string
+	method_params has a value which is a reference to a list where each element is an UnspecifiedObject, which can hold any non-null object
+	script has a value which is a string
+	script_ver has a value which is a string
+	script_command_line has a value which is a string
+	input_ws_objects has a value which is a reference to a list where each element is a Workspace.obj_ref
+	resolved_ws_objects has a value which is a reference to a list where each element is a Workspace.obj_ref
+	intermediate_incoming has a value which is a reference to a list where each element is a string
+	intermediate_outgoing has a value which is a reference to a list where each element is a string
+	external_data has a value which is a reference to a list where each element is a Workspace.ExternalDataUnit
+	subactions has a value which is a reference to a list where each element is a Workspace.SubAction
+	custom has a value which is a reference to a hash where the key is a string and the value is a string
+	description has a value which is a string
+epoch is an int
+obj_ref is a string
+ExternalDataUnit is a reference to a hash where the following keys are defined:
+	resource_name has a value which is a string
+	resource_url has a value which is a string
+	resource_version has a value which is a string
+	resource_release_date has a value which is a Workspace.timestamp
+	resource_release_epoch has a value which is a Workspace.epoch
+	data_url has a value which is a string
+	data_id has a value which is a string
+	description has a value which is a string
+SubAction is a reference to a hash where the following keys are defined:
+	name has a value which is a string
+	ver has a value which is a string
+	code_url has a value which is a string
+	commit has a value which is a string
+	endpoint_url has a value which is a string
+
+
+=end text
+
+=item Description
+
+
+
+=back
+
+=cut
+
+ sub get_legacy_genome
+{
+    my($self, @args) = @_;
+
+# Authentication: required
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function get_legacy_genome (received $n, expecting 1)");
+    }
+    {
+	my($params) = @args;
+
+	my @_bad_arguments;
+        (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to get_legacy_genome:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'get_legacy_genome');
+	}
+    }
+
+    my $url = $self->{url};
+    my $result = $self->{client}->call($url, $self->{headers}, {
+	    method => "GenomeAnnotationAPI.get_legacy_genome",
+	    params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'get_legacy_genome',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method get_legacy_genome",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'get_legacy_genome',
+				       );
+    }
+}
+ 
+
+
+=head2 save_one_legacy_genome
+
+  $result = $obj->save_one_legacy_genome($params)
+
+=over 4
+
+=item Parameter and return types
+
+=begin html
+
+<pre>
+$params is a GenomeAnnotationAPI.SaveLegacyGenomeParams
+$result is a GenomeAnnotationAPI.SaveLegacyGenomeResult
+SaveLegacyGenomeParams is a reference to a hash where the following keys are defined:
+	workspace has a value which is a string
+	name has a value which is a string
+	genomes has a value which is a reference to a list where each element is a GenomeAnnotationAPI.LegacyGenomeSaveData
+LegacyGenomeSaveData is a reference to a hash where the following keys are defined:
+	data has a value which is a KBaseGenomes.Genome
+	hidden has a value which is a GenomeAnnotationAPI.boolean
+	provenance has a value which is a reference to a list where each element is a Workspace.ProvenanceAction
+Genome is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Genome_id
+	scientific_name has a value which is a string
+	domain has a value which is a string
+	genetic_code has a value which is an int
+	dna_size has a value which is an int
+	num_contigs has a value which is an int
+	contigs has a value which is a reference to a list where each element is a KBaseGenomes.Contig
+	contig_lengths has a value which is a reference to a list where each element is an int
+	contig_ids has a value which is a reference to a list where each element is a KBaseGenomes.Contig_id
+	source has a value which is a string
+	source_id has a value which is a KBaseGenomes.source_id
+	md5 has a value which is a string
+	taxonomy has a value which is a string
+	gc_content has a value which is a float
+	complete has a value which is an int
+	publications has a value which is a reference to a list where each element is a KBaseGenomes.publication
+	features has a value which is a reference to a list where each element is a KBaseGenomes.Feature
+	contigset_ref has a value which is a KBaseGenomes.ContigSet_ref
+	assembly_ref has a value which is a KBaseGenomes.Assembly_ref
+	quality has a value which is a KBaseGenomes.Genome_quality_measure
+	close_genomes has a value which is a reference to a list where each element is a KBaseGenomes.Close_genome
+	analysis_events has a value which is a reference to a list where each element is a KBaseGenomes.Analysis_event
+Genome_id is a string
+Contig is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Contig_id
+	length has a value which is an int
+	md5 has a value which is a string
+	sequence has a value which is a string
+	genetic_code has a value which is an int
+	cell_compartment has a value which is a string
+	replicon_type has a value which is a string
+	replicon_geometry has a value which is a string
+	name has a value which is a string
+	description has a value which is a string
+	complete has a value which is a KBaseGenomes.Bool
+Contig_id is a string
+Bool is an int
+source_id is a string
+publication is a reference to a list containing 7 items:
+	0: (id) an int
+	1: (source_db) a string
+	2: (article_title) a string
+	3: (link) a string
+	4: (pubdate) a string
+	5: (authors) a string
+	6: (journal_name) a string
+Feature is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Feature_id
+	location has a value which is a reference to a list where each element is a reference to a list containing 4 items:
+		0: a KBaseGenomes.Contig_id
+		1: an int
+		2: a string
+		3: an int
+
+	type has a value which is a string
+	function has a value which is a string
+	ontology_terms has a value which is a reference to a hash where the key is a string and the value is a reference to a hash where the key is a string and the value is a KBaseGenomes.OntologyData
+	md5 has a value which is a string
+	protein_translation has a value which is a string
+	dna_sequence has a value which is a string
+	protein_translation_length has a value which is an int
+	dna_sequence_length has a value which is an int
+	publications has a value which is a reference to a list where each element is a KBaseGenomes.publication
+	subsystems has a value which is a reference to a list where each element is a string
+	protein_families has a value which is a reference to a list where each element is a KBaseGenomes.ProteinFamily
+	aliases has a value which is a reference to a list where each element is a string
+	orthologs has a value which is a reference to a list where each element is a reference to a list containing 2 items:
+		0: a string
+		1: a float
+
+	annotations has a value which is a reference to a list where each element is a KBaseGenomes.annotation
+	subsystem_data has a value which is a reference to a list where each element is a KBaseGenomes.subsystem_data
+	regulon_data has a value which is a reference to a list where each element is a KBaseGenomes.regulon_data
+	atomic_regulons has a value which is a reference to a list where each element is a KBaseGenomes.atomic_regulon
+	coexpressed_fids has a value which is a reference to a list where each element is a KBaseGenomes.coexpressed_fid
+	co_occurring_fids has a value which is a reference to a list where each element is a KBaseGenomes.co_occurring_fid
+	quality has a value which is a KBaseGenomes.Feature_quality_measure
+	feature_creation_event has a value which is a KBaseGenomes.Analysis_event
+Feature_id is a string
+OntologyData is a reference to a hash where the following keys are defined:
+	id has a value which is a string
+	ontology_ref has a value which is a string
+	term_lineage has a value which is a reference to a list where each element is a string
+	term_name has a value which is a string
+	evidence has a value which is a reference to a list where each element is a KBaseGenomes.OntologyEvidence
+OntologyEvidence is a reference to a hash where the following keys are defined:
+	method has a value which is a string
+	method_version has a value which is a string
+	timestamp has a value which is a string
+	translation_provenance has a value which is a reference to a list containing 3 items:
+		0: (ontologytranslation_ref) a string
+		1: (namespace) a string
+		2: (source_term) a string
+
+	alignment_evidence has a value which is a reference to a list where each element is a reference to a list containing 4 items:
+		0: (start) an int
+		1: (stop) an int
+		2: (align_length) an int
+		3: (identify) a float
+
+ProteinFamily is a reference to a hash where the following keys are defined:
+	id has a value which is a string
+	subject_db has a value which is a string
+	release_version has a value which is a string
+	subject_description has a value which is a string
+	query_begin has a value which is an int
+	query_end has a value which is an int
+	subject_begin has a value which is an int
+	subject_end has a value which is an int
+	score has a value which is a float
+	evalue has a value which is a float
+annotation is a reference to a list containing 3 items:
+	0: (comment) a string
+	1: (annotator) a string
+	2: (annotation_time) a float
+subsystem_data is a reference to a list containing 3 items:
+	0: (subsystem) a string
+	1: (variant) a string
+	2: (role) a string
+regulon_data is a reference to a list containing 3 items:
+	0: (regulon_id) a string
+	1: (regulon_set) a reference to a list where each element is a KBaseGenomes.Feature_id
+	2: (tfs) a reference to a list where each element is a KBaseGenomes.Feature_id
+atomic_regulon is a reference to a list containing 2 items:
+	0: (atomic_regulon_id) a string
+	1: (atomic_regulon_size) an int
+coexpressed_fid is a reference to a list containing 2 items:
+	0: (scored_fid) a KBaseGenomes.Feature_id
+	1: (score) a float
+co_occurring_fid is a reference to a list containing 2 items:
+	0: (scored_fid) a KBaseGenomes.Feature_id
+	1: (score) a float
+Feature_quality_measure is a reference to a hash where the following keys are defined:
+	truncated_begin has a value which is a KBaseGenomes.Bool
+	truncated_end has a value which is a KBaseGenomes.Bool
+	existence_confidence has a value which is a float
+	frameshifted has a value which is a KBaseGenomes.Bool
+	selenoprotein has a value which is a KBaseGenomes.Bool
+	pyrrolysylprotein has a value which is a KBaseGenomes.Bool
+	overlap_rules has a value which is a reference to a list where each element is a string
+	existence_priority has a value which is a float
+	hit_count has a value which is a float
+	weighted_hit_count has a value which is a float
+Analysis_event is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Analysis_event_id
+	tool_name has a value which is a string
+	execution_time has a value which is a float
+	parameters has a value which is a reference to a list where each element is a string
+	hostname has a value which is a string
+Analysis_event_id is a string
+ContigSet_ref is a string
+Assembly_ref is a string
+Genome_quality_measure is a reference to a hash where the following keys are defined:
+	frameshift_error_rate has a value which is a float
+	sequence_error_rate has a value which is a float
+Close_genome is a reference to a hash where the following keys are defined:
+	genome has a value which is a KBaseGenomes.Genome_id
+	closeness_measure has a value which is a float
+boolean is an int
+ProvenanceAction is a reference to a hash where the following keys are defined:
+	time has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
+	caller has a value which is a string
+	service has a value which is a string
+	service_ver has a value which is a string
+	method has a value which is a string
+	method_params has a value which is a reference to a list where each element is an UnspecifiedObject, which can hold any non-null object
+	script has a value which is a string
+	script_ver has a value which is a string
+	script_command_line has a value which is a string
+	input_ws_objects has a value which is a reference to a list where each element is a Workspace.obj_ref
+	resolved_ws_objects has a value which is a reference to a list where each element is a Workspace.obj_ref
+	intermediate_incoming has a value which is a reference to a list where each element is a string
+	intermediate_outgoing has a value which is a reference to a list where each element is a string
+	external_data has a value which is a reference to a list where each element is a Workspace.ExternalDataUnit
+	subactions has a value which is a reference to a list where each element is a Workspace.SubAction
+	custom has a value which is a reference to a hash where the key is a string and the value is a string
+	description has a value which is a string
+timestamp is a string
+epoch is an int
+obj_ref is a string
+ExternalDataUnit is a reference to a hash where the following keys are defined:
+	resource_name has a value which is a string
+	resource_url has a value which is a string
+	resource_version has a value which is a string
+	resource_release_date has a value which is a Workspace.timestamp
+	resource_release_epoch has a value which is a Workspace.epoch
+	data_url has a value which is a string
+	data_id has a value which is a string
+	description has a value which is a string
+SubAction is a reference to a hash where the following keys are defined:
+	name has a value which is a string
+	ver has a value which is a string
+	code_url has a value which is a string
+	commit has a value which is a string
+	endpoint_url has a value which is a string
+SaveLegacyGenomeResult is a reference to a hash where the following keys are defined:
+	info has a value which is a reference to a list where each element is a Workspace.object_info
+object_info is a reference to a list containing 11 items:
+	0: (objid) a Workspace.obj_id
+	1: (name) a Workspace.obj_name
+	2: (type) a Workspace.type_string
+	3: (save_date) a Workspace.timestamp
+	4: (version) an int
+	5: (saved_by) a Workspace.username
+	6: (wsid) a Workspace.ws_id
+	7: (workspace) a Workspace.ws_name
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a Workspace.usermeta
+obj_id is an int
+obj_name is a string
+type_string is a string
+username is a string
+ws_id is an int
+ws_name is a string
+usermeta is a reference to a hash where the key is a string and the value is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+$params is a GenomeAnnotationAPI.SaveLegacyGenomeParams
+$result is a GenomeAnnotationAPI.SaveLegacyGenomeResult
+SaveLegacyGenomeParams is a reference to a hash where the following keys are defined:
+	workspace has a value which is a string
+	name has a value which is a string
+	genomes has a value which is a reference to a list where each element is a GenomeAnnotationAPI.LegacyGenomeSaveData
+LegacyGenomeSaveData is a reference to a hash where the following keys are defined:
+	data has a value which is a KBaseGenomes.Genome
+	hidden has a value which is a GenomeAnnotationAPI.boolean
+	provenance has a value which is a reference to a list where each element is a Workspace.ProvenanceAction
+Genome is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Genome_id
+	scientific_name has a value which is a string
+	domain has a value which is a string
+	genetic_code has a value which is an int
+	dna_size has a value which is an int
+	num_contigs has a value which is an int
+	contigs has a value which is a reference to a list where each element is a KBaseGenomes.Contig
+	contig_lengths has a value which is a reference to a list where each element is an int
+	contig_ids has a value which is a reference to a list where each element is a KBaseGenomes.Contig_id
+	source has a value which is a string
+	source_id has a value which is a KBaseGenomes.source_id
+	md5 has a value which is a string
+	taxonomy has a value which is a string
+	gc_content has a value which is a float
+	complete has a value which is an int
+	publications has a value which is a reference to a list where each element is a KBaseGenomes.publication
+	features has a value which is a reference to a list where each element is a KBaseGenomes.Feature
+	contigset_ref has a value which is a KBaseGenomes.ContigSet_ref
+	assembly_ref has a value which is a KBaseGenomes.Assembly_ref
+	quality has a value which is a KBaseGenomes.Genome_quality_measure
+	close_genomes has a value which is a reference to a list where each element is a KBaseGenomes.Close_genome
+	analysis_events has a value which is a reference to a list where each element is a KBaseGenomes.Analysis_event
+Genome_id is a string
+Contig is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Contig_id
+	length has a value which is an int
+	md5 has a value which is a string
+	sequence has a value which is a string
+	genetic_code has a value which is an int
+	cell_compartment has a value which is a string
+	replicon_type has a value which is a string
+	replicon_geometry has a value which is a string
+	name has a value which is a string
+	description has a value which is a string
+	complete has a value which is a KBaseGenomes.Bool
+Contig_id is a string
+Bool is an int
+source_id is a string
+publication is a reference to a list containing 7 items:
+	0: (id) an int
+	1: (source_db) a string
+	2: (article_title) a string
+	3: (link) a string
+	4: (pubdate) a string
+	5: (authors) a string
+	6: (journal_name) a string
+Feature is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Feature_id
+	location has a value which is a reference to a list where each element is a reference to a list containing 4 items:
+		0: a KBaseGenomes.Contig_id
+		1: an int
+		2: a string
+		3: an int
+
+	type has a value which is a string
+	function has a value which is a string
+	ontology_terms has a value which is a reference to a hash where the key is a string and the value is a reference to a hash where the key is a string and the value is a KBaseGenomes.OntologyData
+	md5 has a value which is a string
+	protein_translation has a value which is a string
+	dna_sequence has a value which is a string
+	protein_translation_length has a value which is an int
+	dna_sequence_length has a value which is an int
+	publications has a value which is a reference to a list where each element is a KBaseGenomes.publication
+	subsystems has a value which is a reference to a list where each element is a string
+	protein_families has a value which is a reference to a list where each element is a KBaseGenomes.ProteinFamily
+	aliases has a value which is a reference to a list where each element is a string
+	orthologs has a value which is a reference to a list where each element is a reference to a list containing 2 items:
+		0: a string
+		1: a float
+
+	annotations has a value which is a reference to a list where each element is a KBaseGenomes.annotation
+	subsystem_data has a value which is a reference to a list where each element is a KBaseGenomes.subsystem_data
+	regulon_data has a value which is a reference to a list where each element is a KBaseGenomes.regulon_data
+	atomic_regulons has a value which is a reference to a list where each element is a KBaseGenomes.atomic_regulon
+	coexpressed_fids has a value which is a reference to a list where each element is a KBaseGenomes.coexpressed_fid
+	co_occurring_fids has a value which is a reference to a list where each element is a KBaseGenomes.co_occurring_fid
+	quality has a value which is a KBaseGenomes.Feature_quality_measure
+	feature_creation_event has a value which is a KBaseGenomes.Analysis_event
+Feature_id is a string
+OntologyData is a reference to a hash where the following keys are defined:
+	id has a value which is a string
+	ontology_ref has a value which is a string
+	term_lineage has a value which is a reference to a list where each element is a string
+	term_name has a value which is a string
+	evidence has a value which is a reference to a list where each element is a KBaseGenomes.OntologyEvidence
+OntologyEvidence is a reference to a hash where the following keys are defined:
+	method has a value which is a string
+	method_version has a value which is a string
+	timestamp has a value which is a string
+	translation_provenance has a value which is a reference to a list containing 3 items:
+		0: (ontologytranslation_ref) a string
+		1: (namespace) a string
+		2: (source_term) a string
+
+	alignment_evidence has a value which is a reference to a list where each element is a reference to a list containing 4 items:
+		0: (start) an int
+		1: (stop) an int
+		2: (align_length) an int
+		3: (identify) a float
+
+ProteinFamily is a reference to a hash where the following keys are defined:
+	id has a value which is a string
+	subject_db has a value which is a string
+	release_version has a value which is a string
+	subject_description has a value which is a string
+	query_begin has a value which is an int
+	query_end has a value which is an int
+	subject_begin has a value which is an int
+	subject_end has a value which is an int
+	score has a value which is a float
+	evalue has a value which is a float
+annotation is a reference to a list containing 3 items:
+	0: (comment) a string
+	1: (annotator) a string
+	2: (annotation_time) a float
+subsystem_data is a reference to a list containing 3 items:
+	0: (subsystem) a string
+	1: (variant) a string
+	2: (role) a string
+regulon_data is a reference to a list containing 3 items:
+	0: (regulon_id) a string
+	1: (regulon_set) a reference to a list where each element is a KBaseGenomes.Feature_id
+	2: (tfs) a reference to a list where each element is a KBaseGenomes.Feature_id
+atomic_regulon is a reference to a list containing 2 items:
+	0: (atomic_regulon_id) a string
+	1: (atomic_regulon_size) an int
+coexpressed_fid is a reference to a list containing 2 items:
+	0: (scored_fid) a KBaseGenomes.Feature_id
+	1: (score) a float
+co_occurring_fid is a reference to a list containing 2 items:
+	0: (scored_fid) a KBaseGenomes.Feature_id
+	1: (score) a float
+Feature_quality_measure is a reference to a hash where the following keys are defined:
+	truncated_begin has a value which is a KBaseGenomes.Bool
+	truncated_end has a value which is a KBaseGenomes.Bool
+	existence_confidence has a value which is a float
+	frameshifted has a value which is a KBaseGenomes.Bool
+	selenoprotein has a value which is a KBaseGenomes.Bool
+	pyrrolysylprotein has a value which is a KBaseGenomes.Bool
+	overlap_rules has a value which is a reference to a list where each element is a string
+	existence_priority has a value which is a float
+	hit_count has a value which is a float
+	weighted_hit_count has a value which is a float
+Analysis_event is a reference to a hash where the following keys are defined:
+	id has a value which is a KBaseGenomes.Analysis_event_id
+	tool_name has a value which is a string
+	execution_time has a value which is a float
+	parameters has a value which is a reference to a list where each element is a string
+	hostname has a value which is a string
+Analysis_event_id is a string
+ContigSet_ref is a string
+Assembly_ref is a string
+Genome_quality_measure is a reference to a hash where the following keys are defined:
+	frameshift_error_rate has a value which is a float
+	sequence_error_rate has a value which is a float
+Close_genome is a reference to a hash where the following keys are defined:
+	genome has a value which is a KBaseGenomes.Genome_id
+	closeness_measure has a value which is a float
+boolean is an int
+ProvenanceAction is a reference to a hash where the following keys are defined:
+	time has a value which is a Workspace.timestamp
+	epoch has a value which is a Workspace.epoch
+	caller has a value which is a string
+	service has a value which is a string
+	service_ver has a value which is a string
+	method has a value which is a string
+	method_params has a value which is a reference to a list where each element is an UnspecifiedObject, which can hold any non-null object
+	script has a value which is a string
+	script_ver has a value which is a string
+	script_command_line has a value which is a string
+	input_ws_objects has a value which is a reference to a list where each element is a Workspace.obj_ref
+	resolved_ws_objects has a value which is a reference to a list where each element is a Workspace.obj_ref
+	intermediate_incoming has a value which is a reference to a list where each element is a string
+	intermediate_outgoing has a value which is a reference to a list where each element is a string
+	external_data has a value which is a reference to a list where each element is a Workspace.ExternalDataUnit
+	subactions has a value which is a reference to a list where each element is a Workspace.SubAction
+	custom has a value which is a reference to a hash where the key is a string and the value is a string
+	description has a value which is a string
+timestamp is a string
+epoch is an int
+obj_ref is a string
+ExternalDataUnit is a reference to a hash where the following keys are defined:
+	resource_name has a value which is a string
+	resource_url has a value which is a string
+	resource_version has a value which is a string
+	resource_release_date has a value which is a Workspace.timestamp
+	resource_release_epoch has a value which is a Workspace.epoch
+	data_url has a value which is a string
+	data_id has a value which is a string
+	description has a value which is a string
+SubAction is a reference to a hash where the following keys are defined:
+	name has a value which is a string
+	ver has a value which is a string
+	code_url has a value which is a string
+	commit has a value which is a string
+	endpoint_url has a value which is a string
+SaveLegacyGenomeResult is a reference to a hash where the following keys are defined:
+	info has a value which is a reference to a list where each element is a Workspace.object_info
+object_info is a reference to a list containing 11 items:
+	0: (objid) a Workspace.obj_id
+	1: (name) a Workspace.obj_name
+	2: (type) a Workspace.type_string
+	3: (save_date) a Workspace.timestamp
+	4: (version) an int
+	5: (saved_by) a Workspace.username
+	6: (wsid) a Workspace.ws_id
+	7: (workspace) a Workspace.ws_name
+	8: (chsum) a string
+	9: (size) an int
+	10: (meta) a Workspace.usermeta
+obj_id is an int
+obj_name is a string
+type_string is a string
+username is a string
+ws_id is an int
+ws_name is a string
+usermeta is a reference to a hash where the key is a string and the value is a string
+
+
+=end text
+
+=item Description
+
+
+
+=back
+
+=cut
+
+ sub save_one_legacy_genome
+{
+    my($self, @args) = @_;
+
+# Authentication: required
+
+    if ((my $n = @args) != 1)
+    {
+	Bio::KBase::Exceptions::ArgumentValidationError->throw(error =>
+							       "Invalid argument count for function save_one_legacy_genome (received $n, expecting 1)");
+    }
+    {
+	my($params) = @args;
+
+	my @_bad_arguments;
+        (ref($params) eq 'HASH') or push(@_bad_arguments, "Invalid type for argument 1 \"params\" (value was \"$params\")");
+        if (@_bad_arguments) {
+	    my $msg = "Invalid arguments passed to save_one_legacy_genome:\n" . join("", map { "\t$_\n" } @_bad_arguments);
+	    Bio::KBase::Exceptions::ArgumentValidationError->throw(error => $msg,
+								   method_name => 'save_one_legacy_genome');
+	}
+    }
+
+    my $url = $self->{url};
+    my $result = $self->{client}->call($url, $self->{headers}, {
+	    method => "GenomeAnnotationAPI.save_one_legacy_genome",
+	    params => \@args,
+    });
+    if ($result) {
+	if ($result->is_error) {
+	    Bio::KBase::Exceptions::JSONRPC->throw(error => $result->error_message,
+					       code => $result->content->{error}->{code},
+					       method_name => 'save_one_legacy_genome',
+					       data => $result->content->{error}->{error} # JSON::RPC::ReturnObject only supports JSONRPC 1.1 or 1.O
+					      );
+	} else {
+	    return wantarray ? @{$result->result} : $result->result->[0];
+	}
+    } else {
+        Bio::KBase::Exceptions::HTTP->throw(error => "Error invoking method save_one_legacy_genome",
+					    status_line => $self->{client}->status_line,
+					    method_name => 'save_one_legacy_genome',
+				       );
+    }
+}
+ 
   
 sub status
 {
@@ -2797,16 +3885,16 @@ sub version {
             Bio::KBase::Exceptions::JSONRPC->throw(
                 error => $result->error_message,
                 code => $result->content->{code},
-                method_name => 'get_combined_data',
+                method_name => 'save_one_legacy_genome',
             );
         } else {
             return wantarray ? @{$result->result} : $result->result->[0];
         }
     } else {
         Bio::KBase::Exceptions::HTTP->throw(
-            error => "Error invoking method get_combined_data",
+            error => "Error invoking method save_one_legacy_genome",
             status_line => $self->{client}->status_line,
-            method_name => 'get_combined_data',
+            method_name => 'save_one_legacy_genome',
         );
     }
 }
@@ -4265,6 +5353,257 @@ include_cds_id_by_mrna_id has a value which is a GenomeAnnotationAPI.boolean
 include_exons_by_mrna_id has a value which is a GenomeAnnotationAPI.boolean
 include_utr_by_utr_type_by_mrna_id has a value which is a GenomeAnnotationAPI.boolean
 exclude_summary has a value which is a GenomeAnnotationAPI.boolean
+
+
+=end text
+
+=back
+
+
+
+=head2 LegacyGenomeSelector
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+ref has a value which is a string
+included has a value which is a reference to a list where each element is a string
+ref_path_to_genome has a value which is a reference to a list where each element is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+ref has a value which is a string
+included has a value which is a reference to a list where each element is a string
+ref_path_to_genome has a value which is a reference to a list where each element is a string
+
+
+=end text
+
+=back
+
+
+
+=head2 GetLegacyGenomeParams
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+genomes has a value which is a reference to a list where each element is a GenomeAnnotationAPI.LegacyGenomeSelector
+ignore_errors has a value which is a GenomeAnnotationAPI.boolean
+no_data has a value which is a GenomeAnnotationAPI.boolean
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+genomes has a value which is a reference to a list where each element is a GenomeAnnotationAPI.LegacyGenomeSelector
+ignore_errors has a value which is a GenomeAnnotationAPI.boolean
+no_data has a value which is a GenomeAnnotationAPI.boolean
+
+
+=end text
+
+=back
+
+
+
+=head2 LegacyGenomeData
+
+=over 4
+
+
+
+=item Description
+
+todo: import Genome type and use it here
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+data has a value which is a KBaseGenomes.Genome
+info has a value which is a Workspace.object_info
+provenance has a value which is a reference to a list where each element is a Workspace.ProvenanceAction
+creator has a value which is a string
+orig_wsid has a value which is a string
+copied has a value which is a string
+copy_source_inaccessible has a value which is a GenomeAnnotationAPI.boolean
+created has a value which is a Workspace.timestamp
+epoch has a value which is a Workspace.epoch
+handle_error has a value which is a string
+handle_stacktrace has a value which is a string
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+data has a value which is a KBaseGenomes.Genome
+info has a value which is a Workspace.object_info
+provenance has a value which is a reference to a list where each element is a Workspace.ProvenanceAction
+creator has a value which is a string
+orig_wsid has a value which is a string
+copied has a value which is a string
+copy_source_inaccessible has a value which is a GenomeAnnotationAPI.boolean
+created has a value which is a Workspace.timestamp
+epoch has a value which is a Workspace.epoch
+handle_error has a value which is a string
+handle_stacktrace has a value which is a string
+
+
+=end text
+
+=back
+
+
+
+=head2 LegacyGenomeDataSet
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+genomes has a value which is a reference to a list where each element is a GenomeAnnotationAPI.LegacyGenomeData
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+genomes has a value which is a reference to a list where each element is a GenomeAnnotationAPI.LegacyGenomeData
+
+
+=end text
+
+=back
+
+
+
+=head2 LegacyGenomeSaveData
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+data has a value which is a KBaseGenomes.Genome
+hidden has a value which is a GenomeAnnotationAPI.boolean
+provenance has a value which is a reference to a list where each element is a Workspace.ProvenanceAction
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+data has a value which is a KBaseGenomes.Genome
+hidden has a value which is a GenomeAnnotationAPI.boolean
+provenance has a value which is a reference to a list where each element is a Workspace.ProvenanceAction
+
+
+=end text
+
+=back
+
+
+
+=head2 SaveLegacyGenomeParams
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+workspace has a value which is a string
+name has a value which is a string
+genomes has a value which is a reference to a list where each element is a GenomeAnnotationAPI.LegacyGenomeSaveData
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+workspace has a value which is a string
+name has a value which is a string
+genomes has a value which is a reference to a list where each element is a GenomeAnnotationAPI.LegacyGenomeSaveData
+
+
+=end text
+
+=back
+
+
+
+=head2 SaveLegacyGenomeResult
+
+=over 4
+
+
+
+=item Definition
+
+=begin html
+
+<pre>
+a reference to a hash where the following keys are defined:
+info has a value which is a reference to a list where each element is a Workspace.object_info
+
+</pre>
+
+=end html
+
+=begin text
+
+a reference to a hash where the following keys are defined:
+info has a value which is a reference to a list where each element is a Workspace.object_info
 
 
 =end text

--- a/lib/GenomeAnnotationAPI/GenomeAnnotationAPIClient.py
+++ b/lib/GenomeAnnotationAPI/GenomeAnnotationAPIClient.py
@@ -498,6 +498,705 @@ class GenomeAnnotationAPI(object):
             'GenomeAnnotationAPI.get_combined_data',
             [params], self._service_ver, context)
 
+    def get_legacy_genome(self, params, context=None):
+        """
+        :param params: instance of type "GetLegacyGenomeParams" -> structure:
+           parameter "genomes" of list of type "LegacyGenomeSelector" ->
+           structure: parameter "ref" of String, parameter "included" of list
+           of String, parameter "ref_path_to_genome" of list of String,
+           parameter "ignore_errors" of type "boolean" (A boolean - 0 for
+           false, 1 for true. @range (0, 1)), parameter "no_data" of type
+           "boolean" (A boolean - 0 for false, 1 for true. @range (0, 1))
+        :returns: instance of type "LegacyGenomeData" (todo: import Genome
+           type and use it here) -> structure: parameter "data" of type
+           "Genome" (Genome object holds much of the data relevant for a
+           genome in KBase Genome publications should be papers about the
+           genome, not papers about certain features of the genome (which go
+           into the Feature object) Should the Genome object have a list of
+           feature ids? (in addition to having a list of feature_refs) Should
+           the Genome object contain a list of contig_ids too? @optional
+           assembly_ref quality close_genomes analysis_events features
+           source_id source contigs contig_ids publications md5 taxonomy
+           gc_content complete dna_size num_contigs contig_lengths
+           contigset_ref @metadata ws gc_content as GC content @metadata ws
+           taxonomy as Taxonomy @metadata ws md5 as MD5 @metadata ws dna_size
+           as Size @metadata ws genetic_code as Genetic code @metadata ws
+           domain as Domain @metadata ws source_id as Source ID @metadata ws
+           source as Source @metadata ws scientific_name as Name @metadata ws
+           length(close_genomes) as Close genomes @metadata ws
+           length(features) as Number features @metadata ws num_contigs as
+           Number contigs) -> structure: parameter "id" of type "Genome_id"
+           (KBase genome ID @id kb), parameter "scientific_name" of String,
+           parameter "domain" of String, parameter "genetic_code" of Long,
+           parameter "dna_size" of Long, parameter "num_contigs" of Long,
+           parameter "contigs" of list of type "Contig" (Type spec for a
+           "Contig" subobject in the "ContigSet" object Contig_id id - ID of
+           contig in contigset string md5 - unique hash of contig sequence
+           string sequence - sequence of the contig string description -
+           Description of the contig (e.g. everything after the ID in a FASTA
+           file) @optional length md5 genetic_code cell_compartment
+           replicon_geometry replicon_type name description complete) ->
+           structure: parameter "id" of type "Contig_id" (ContigSet contig ID
+           @id external), parameter "length" of Long, parameter "md5" of
+           String, parameter "sequence" of String, parameter "genetic_code"
+           of Long, parameter "cell_compartment" of String, parameter
+           "replicon_type" of String, parameter "replicon_geometry" of
+           String, parameter "name" of String, parameter "description" of
+           String, parameter "complete" of type "Bool", parameter
+           "contig_lengths" of list of Long, parameter "contig_ids" of list
+           of type "Contig_id" (ContigSet contig ID @id external), parameter
+           "source" of String, parameter "source_id" of type "source_id"
+           (Reference to a source_id @id external), parameter "md5" of
+           String, parameter "taxonomy" of String, parameter "gc_content" of
+           Double, parameter "complete" of Long, parameter "publications" of
+           list of type "publication" (Structure for a publication (from ER
+           API) also want to capture authors, journal name (not in ER)) ->
+           tuple of size 7: parameter "id" of Long, parameter "source_db" of
+           String, parameter "article_title" of String, parameter "link" of
+           String, parameter "pubdate" of String, parameter "authors" of
+           String, parameter "journal_name" of String, parameter "features"
+           of list of type "Feature" (Structure for a single feature of a
+           genome Should genome_id contain the genome_id in the Genome
+           object, the workspace id of the Genome object, a genomeref,
+           something else? Should sequence be in separate objects too? We may
+           want to add additional fields for other CDM functions (e.g.,
+           atomic regulons, coexpressed fids, co_occurring fids,...)
+           @optional orthologs quality feature_creation_event md5 location
+           function ontology_terms protein_translation protein_families
+           subsystems publications subsystem_data aliases annotations
+           regulon_data atomic_regulons coexpressed_fids co_occurring_fids
+           dna_sequence protein_translation_length dna_sequence_length) ->
+           structure: parameter "id" of type "Feature_id" (KBase Feature ID
+           @id external), parameter "location" of list of tuple of size 4:
+           type "Contig_id" (ContigSet contig ID @id external), Long, String,
+           Long, parameter "type" of String, parameter "function" of String,
+           parameter "ontology_terms" of mapping from String to mapping from
+           String to type "OntologyData" -> structure: parameter "id" of
+           String, parameter "ontology_ref" of String, parameter
+           "term_lineage" of list of String, parameter "term_name" of String,
+           parameter "evidence" of list of type "OntologyEvidence" (@optional
+           translation_provenance alignment_evidence) -> structure: parameter
+           "method" of String, parameter "method_version" of String,
+           parameter "timestamp" of String, parameter
+           "translation_provenance" of tuple of size 3: parameter
+           "ontologytranslation_ref" of String, parameter "namespace" of
+           String, parameter "source_term" of String, parameter
+           "alignment_evidence" of list of tuple of size 4: parameter "start"
+           of Long, parameter "stop" of Long, parameter "align_length" of
+           Long, parameter "identify" of Double, parameter "md5" of String,
+           parameter "protein_translation" of String, parameter
+           "dna_sequence" of String, parameter "protein_translation_length"
+           of Long, parameter "dna_sequence_length" of Long, parameter
+           "publications" of list of type "publication" (Structure for a
+           publication (from ER API) also want to capture authors, journal
+           name (not in ER)) -> tuple of size 7: parameter "id" of Long,
+           parameter "source_db" of String, parameter "article_title" of
+           String, parameter "link" of String, parameter "pubdate" of String,
+           parameter "authors" of String, parameter "journal_name" of String,
+           parameter "subsystems" of list of String, parameter
+           "protein_families" of list of type "ProteinFamily" (Structure for
+           a protein family @optional query_begin query_end subject_begin
+           subject_end score evalue subject_description release_version) ->
+           structure: parameter "id" of String, parameter "subject_db" of
+           String, parameter "release_version" of String, parameter
+           "subject_description" of String, parameter "query_begin" of Long,
+           parameter "query_end" of Long, parameter "subject_begin" of Long,
+           parameter "subject_end" of Long, parameter "score" of Double,
+           parameter "evalue" of Double, parameter "aliases" of list of
+           String, parameter "orthologs" of list of tuple of size 2: String,
+           Double, parameter "annotations" of list of type "annotation" (a
+           notation by a curator of the genome object) -> tuple of size 3:
+           parameter "comment" of String, parameter "annotator" of String,
+           parameter "annotation_time" of Double, parameter "subsystem_data"
+           of list of type "subsystem_data" (Structure for subsystem data
+           (from CDMI API)) -> tuple of size 3: parameter "subsystem" of
+           String, parameter "variant" of String, parameter "role" of String,
+           parameter "regulon_data" of list of type "regulon_data" (Structure
+           for regulon data (from CDMI API)) -> tuple of size 3: parameter
+           "regulon_id" of String, parameter "regulon_set" of list of type
+           "Feature_id" (KBase Feature ID @id external), parameter "tfs" of
+           list of type "Feature_id" (KBase Feature ID @id external),
+           parameter "atomic_regulons" of list of type "atomic_regulon"
+           (Structure for an atomic regulon (from CDMI API)) -> tuple of size
+           2: parameter "atomic_regulon_id" of String, parameter
+           "atomic_regulon_size" of Long, parameter "coexpressed_fids" of
+           list of type "coexpressed_fid" (Structure for coexpressed fids
+           (from CDMI API)) -> tuple of size 2: parameter "scored_fid" of
+           type "Feature_id" (KBase Feature ID @id external), parameter
+           "score" of Double, parameter "co_occurring_fids" of list of type
+           "co_occurring_fid" (Structure for co-occurring fids (from CDMI
+           API)) -> tuple of size 2: parameter "scored_fid" of type
+           "Feature_id" (KBase Feature ID @id external), parameter "score" of
+           Double, parameter "quality" of type "Feature_quality_measure"
+           (@optional weighted_hit_count hit_count existence_priority
+           overlap_rules pyrrolysylprotein truncated_begin truncated_end
+           existence_confidence frameshifted selenoprotein) -> structure:
+           parameter "truncated_begin" of type "Bool", parameter
+           "truncated_end" of type "Bool", parameter "existence_confidence"
+           of Double, parameter "frameshifted" of type "Bool", parameter
+           "selenoprotein" of type "Bool", parameter "pyrrolysylprotein" of
+           type "Bool", parameter "overlap_rules" of list of String,
+           parameter "existence_priority" of Double, parameter "hit_count" of
+           Double, parameter "weighted_hit_count" of Double, parameter
+           "feature_creation_event" of type "Analysis_event" (@optional
+           tool_name execution_time parameters hostname) -> structure:
+           parameter "id" of type "Analysis_event_id", parameter "tool_name"
+           of String, parameter "execution_time" of Double, parameter
+           "parameters" of list of String, parameter "hostname" of String,
+           parameter "contigset_ref" of type "ContigSet_ref" (Reference to a
+           ContigSet object containing the contigs for this genome in the
+           workspace @id ws KBaseGenomes.ContigSet), parameter "assembly_ref"
+           of type "Assembly_ref" (Reference to an Assembly object in the
+           workspace @id ws KBaseGenomeAnnotations.Assembly), parameter
+           "quality" of type "Genome_quality_measure" (@optional
+           frameshift_error_rate sequence_error_rate) -> structure: parameter
+           "frameshift_error_rate" of Double, parameter "sequence_error_rate"
+           of Double, parameter "close_genomes" of list of type
+           "Close_genome" (@optional genome closeness_measure) -> structure:
+           parameter "genome" of type "Genome_id" (KBase genome ID @id kb),
+           parameter "closeness_measure" of Double, parameter
+           "analysis_events" of list of type "Analysis_event" (@optional
+           tool_name execution_time parameters hostname) -> structure:
+           parameter "id" of type "Analysis_event_id", parameter "tool_name"
+           of String, parameter "execution_time" of Double, parameter
+           "parameters" of list of String, parameter "hostname" of String,
+           parameter "info" of type "object_info" (Information about an
+           object, including user provided metadata. obj_id objid - the
+           numerical id of the object. obj_name name - the name of the
+           object. type_string type - the type of the object. timestamp
+           save_date - the save date of the object. obj_ver ver - the version
+           of the object. username saved_by - the user that saved or copied
+           the object. ws_id wsid - the workspace containing the object.
+           ws_name workspace - the workspace containing the object. string
+           chsum - the md5 checksum of the object. int size - the size of the
+           object in bytes. usermeta meta - arbitrary user-supplied metadata
+           about the object.) -> tuple of size 11: parameter "objid" of type
+           "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "name" of type "obj_name" (A string used as a name for
+           an object. Any string consisting of alphanumeric characters and
+           the characters |._- that is not an integer is acceptable.),
+           parameter "type" of type "type_string" (A type string. Specifies
+           the type and its version in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "save_date" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "version" of Long,
+           parameter "saved_by" of type "username" (Login name of a KBase
+           user account.), parameter "wsid" of type "ws_id" (The unique,
+           permanent numerical ID of a workspace.), parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "chsum" of String, parameter
+           "size" of Long, parameter "meta" of type "usermeta" (User provided
+           metadata about an object. Arbitrary key-value pairs provided by
+           the user.) -> mapping from String to String, parameter
+           "provenance" of list of type "ProvenanceAction" (A provenance
+           action. A provenance action (PA) is an action taken while
+           transforming one data object to another. There may be several PAs
+           taken in series. A PA is typically running a script, running an
+           api command, etc. All of the following fields are optional, but
+           more information provided equates to better data provenance.
+           resolved_ws_objects should never be set by the user; it is set by
+           the workspace service when returning data. On input, only one of
+           the time or epoch may be supplied. Both are supplied on output.
+           The maximum size of the entire provenance object, including all
+           actions, is 1MB. timestamp time - the time the action was started
+           epoch epoch - the time the action was started. string caller - the
+           name or id of the invoker of this provenance action. In most
+           cases, this will be the same for all PAs. string service - the
+           name of the service that performed this action. string service_ver
+           - the version of the service that performed this action. string
+           method - the method of the service that performed this action.
+           list<UnspecifiedObject> method_params - the parameters of the
+           method that performed this action. If an object in the parameters
+           is a workspace object, also put the object reference in the
+           input_ws_object list. string script - the name of the script that
+           performed this action. string script_ver - the version of the
+           script that performed this action. string script_command_line -
+           the command line provided to the script that performed this
+           action. If workspace objects were provided in the command line,
+           also put the object reference in the input_ws_object list.
+           list<obj_ref> input_ws_objects - the workspace objects that were
+           used as input to this action; typically these will also be present
+           as parts of the method_params or the script_command_line
+           arguments. list<obj_ref> resolved_ws_objects - the workspace
+           objects ids from input_ws_objects resolved to permanent workspace
+           object references by the workspace service. list<string>
+           intermediate_incoming - if the previous action produced output
+           that 1) was not stored in a referrable way, and 2) is used as
+           input for this action, provide it with an arbitrary and unique ID
+           here, in the order of the input arguments to this action. These
+           IDs can be used in the method_params argument. list<string>
+           intermediate_outgoing - if this action produced output that 1) was
+           not stored in a referrable way, and 2) is used as input for the
+           next action, provide it with an arbitrary and unique ID here, in
+           the order of the output values from this action. These IDs can be
+           used in the intermediate_incoming argument in the next action.
+           list<ExternalDataUnit> external_data - data external to the
+           workspace that was either imported to the workspace or used to
+           create a workspace object. list<SubAction> subactions - the
+           subactions taken as a part of this action. mapping<string, string>
+           custom - user definable custom provenance fields and their values.
+           string description - a free text description of this action.) ->
+           structure: parameter "time" of type "timestamp" (A time in the
+           format YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
+           (representing the UTC timezone) or the difference in time to UTC
+           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
+           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
+           time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
+           since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "caller"
+           of String, parameter "service" of String, parameter "service_ver"
+           of String, parameter "method" of String, parameter "method_params"
+           of list of unspecified object, parameter "script" of String,
+           parameter "script_ver" of String, parameter "script_command_line"
+           of String, parameter "input_ws_objects" of list of type "obj_ref"
+           (A string that uniquely identifies an object in the workspace
+           service. There are two ways to uniquely identify an object in one
+           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
+           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
+           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
+           version of an object with id 567 in a workspace with id 23. In all
+           cases, if the version number is omitted, the latest version of the
+           object is assumed.), parameter "resolved_ws_objects" of list of
+           type "obj_ref" (A string that uniquely identifies an object in the
+           workspace service. There are two ways to uniquely identify an
+           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
+           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
+           the third version of an object called MyFirstObject in the
+           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
+           first version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
+           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
+           version of an object with id 567 in a workspace with id 23. In all
+           cases, if the version number is omitted, the latest version of the
+           object is assumed.), parameter "intermediate_incoming" of list of
+           String, parameter "intermediate_outgoing" of list of String,
+           parameter "external_data" of list of type "ExternalDataUnit" (An
+           external data unit. A piece of data from a source outside the
+           Workspace. On input, only one of the resource_release_date or
+           resource_release_epoch may be supplied. Both are supplied on
+           output. string resource_name - the name of the resource, for
+           example JGI. string resource_url - the url of the resource, for
+           example http://genome.jgi.doe.gov string resource_version -
+           version of the resource timestamp resource_release_date - the
+           release date of the resource epoch resource_release_epoch - the
+           release date of the resource string data_url - the url of the
+           data, for example
+           http://genome.jgi.doe.gov/pages/dynamicOrganismDownload.jsf?
+           organism=BlaspURHD0036 string data_id - the id of the data, for
+           example 7625.2.79179.AGTTCC.adnq.fastq.gz string description - a
+           free text description of the data.) -> structure: parameter
+           "resource_name" of String, parameter "resource_url" of String,
+           parameter "resource_version" of String, parameter
+           "resource_release_date" of type "timestamp" (A time in the format
+           YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
+           (representing the UTC timezone) or the difference in time to UTC
+           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
+           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
+           time)), parameter "resource_release_epoch" of type "epoch" (A Unix
+           epoch (the time since 00:00:00 1/1/1970 UTC) in milliseconds.),
+           parameter "data_url" of String, parameter "data_id" of String,
+           parameter "description" of String, parameter "subactions" of list
+           of type "SubAction" (Information about a subaction that is invoked
+           by a provenance action. A provenance action (PA) may invoke
+           subactions (SA), e.g. calling a separate piece of code, a service,
+           or a script. In most cases these calls are the same from PA to PA
+           and so do not need to be listed in the provenance since providing
+           information about the PA alone provides reproducibility. In some
+           cases, however, SAs may change over time, such that invoking the
+           same PA with the same parameters may produce different results.
+           For example, if a PA calls a remote server, that server may be
+           updated between a PA invoked on day T and another PA invoked on
+           day T+1. The SubAction structure allows for specifying information
+           about SAs that may dynamically change from PA invocation to PA
+           invocation. string name - the name of the SA. string ver - the
+           version of SA. string code_url - a url pointing to the SA's
+           codebase. string commit - a version control commit ID for the SA.
+           string endpoint_url - a url pointing to the access point for the
+           SA - a server url, for instance.) -> structure: parameter "name"
+           of String, parameter "ver" of String, parameter "code_url" of
+           String, parameter "commit" of String, parameter "endpoint_url" of
+           String, parameter "custom" of mapping from String to String,
+           parameter "description" of String, parameter "creator" of String,
+           parameter "orig_wsid" of String, parameter "copied" of String,
+           parameter "copy_source_inaccessible" of type "boolean" (A boolean
+           - 0 for false, 1 for true. @range (0, 1)), parameter "created" of
+           type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where
+           Z is either the character Z (representing the UTC timezone) or the
+           difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "epoch" of type
+           "epoch" (A Unix epoch (the time since 00:00:00 1/1/1970 UTC) in
+           milliseconds.), parameter "handle_error" of String, parameter
+           "handle_stacktrace" of String
+        """
+        return self._client.call_method(
+            'GenomeAnnotationAPI.get_legacy_genome',
+            [params], self._service_ver, context)
+
+    def save_one_legacy_genome(self, params, context=None):
+        """
+        :param params: instance of type "SaveLegacyGenomeParams" ->
+           structure: parameter "workspace" of String, parameter "name" of
+           String, parameter "genomes" of list of type "LegacyGenomeSaveData"
+           -> structure: parameter "data" of type "Genome" (Genome object
+           holds much of the data relevant for a genome in KBase Genome
+           publications should be papers about the genome, not papers about
+           certain features of the genome (which go into the Feature object)
+           Should the Genome object have a list of feature ids? (in addition
+           to having a list of feature_refs) Should the Genome object contain
+           a list of contig_ids too? @optional assembly_ref quality
+           close_genomes analysis_events features source_id source contigs
+           contig_ids publications md5 taxonomy gc_content complete dna_size
+           num_contigs contig_lengths contigset_ref @metadata ws gc_content
+           as GC content @metadata ws taxonomy as Taxonomy @metadata ws md5
+           as MD5 @metadata ws dna_size as Size @metadata ws genetic_code as
+           Genetic code @metadata ws domain as Domain @metadata ws source_id
+           as Source ID @metadata ws source as Source @metadata ws
+           scientific_name as Name @metadata ws length(close_genomes) as
+           Close genomes @metadata ws length(features) as Number features
+           @metadata ws num_contigs as Number contigs) -> structure:
+           parameter "id" of type "Genome_id" (KBase genome ID @id kb),
+           parameter "scientific_name" of String, parameter "domain" of
+           String, parameter "genetic_code" of Long, parameter "dna_size" of
+           Long, parameter "num_contigs" of Long, parameter "contigs" of list
+           of type "Contig" (Type spec for a "Contig" subobject in the
+           "ContigSet" object Contig_id id - ID of contig in contigset string
+           md5 - unique hash of contig sequence string sequence - sequence of
+           the contig string description - Description of the contig (e.g.
+           everything after the ID in a FASTA file) @optional length md5
+           genetic_code cell_compartment replicon_geometry replicon_type name
+           description complete) -> structure: parameter "id" of type
+           "Contig_id" (ContigSet contig ID @id external), parameter "length"
+           of Long, parameter "md5" of String, parameter "sequence" of
+           String, parameter "genetic_code" of Long, parameter
+           "cell_compartment" of String, parameter "replicon_type" of String,
+           parameter "replicon_geometry" of String, parameter "name" of
+           String, parameter "description" of String, parameter "complete" of
+           type "Bool", parameter "contig_lengths" of list of Long, parameter
+           "contig_ids" of list of type "Contig_id" (ContigSet contig ID @id
+           external), parameter "source" of String, parameter "source_id" of
+           type "source_id" (Reference to a source_id @id external),
+           parameter "md5" of String, parameter "taxonomy" of String,
+           parameter "gc_content" of Double, parameter "complete" of Long,
+           parameter "publications" of list of type "publication" (Structure
+           for a publication (from ER API) also want to capture authors,
+           journal name (not in ER)) -> tuple of size 7: parameter "id" of
+           Long, parameter "source_db" of String, parameter "article_title"
+           of String, parameter "link" of String, parameter "pubdate" of
+           String, parameter "authors" of String, parameter "journal_name" of
+           String, parameter "features" of list of type "Feature" (Structure
+           for a single feature of a genome Should genome_id contain the
+           genome_id in the Genome object, the workspace id of the Genome
+           object, a genomeref, something else? Should sequence be in
+           separate objects too? We may want to add additional fields for
+           other CDM functions (e.g., atomic regulons, coexpressed fids,
+           co_occurring fids,...) @optional orthologs quality
+           feature_creation_event md5 location function ontology_terms
+           protein_translation protein_families subsystems publications
+           subsystem_data aliases annotations regulon_data atomic_regulons
+           coexpressed_fids co_occurring_fids dna_sequence
+           protein_translation_length dna_sequence_length) -> structure:
+           parameter "id" of type "Feature_id" (KBase Feature ID @id
+           external), parameter "location" of list of tuple of size 4: type
+           "Contig_id" (ContigSet contig ID @id external), Long, String,
+           Long, parameter "type" of String, parameter "function" of String,
+           parameter "ontology_terms" of mapping from String to mapping from
+           String to type "OntologyData" -> structure: parameter "id" of
+           String, parameter "ontology_ref" of String, parameter
+           "term_lineage" of list of String, parameter "term_name" of String,
+           parameter "evidence" of list of type "OntologyEvidence" (@optional
+           translation_provenance alignment_evidence) -> structure: parameter
+           "method" of String, parameter "method_version" of String,
+           parameter "timestamp" of String, parameter
+           "translation_provenance" of tuple of size 3: parameter
+           "ontologytranslation_ref" of String, parameter "namespace" of
+           String, parameter "source_term" of String, parameter
+           "alignment_evidence" of list of tuple of size 4: parameter "start"
+           of Long, parameter "stop" of Long, parameter "align_length" of
+           Long, parameter "identify" of Double, parameter "md5" of String,
+           parameter "protein_translation" of String, parameter
+           "dna_sequence" of String, parameter "protein_translation_length"
+           of Long, parameter "dna_sequence_length" of Long, parameter
+           "publications" of list of type "publication" (Structure for a
+           publication (from ER API) also want to capture authors, journal
+           name (not in ER)) -> tuple of size 7: parameter "id" of Long,
+           parameter "source_db" of String, parameter "article_title" of
+           String, parameter "link" of String, parameter "pubdate" of String,
+           parameter "authors" of String, parameter "journal_name" of String,
+           parameter "subsystems" of list of String, parameter
+           "protein_families" of list of type "ProteinFamily" (Structure for
+           a protein family @optional query_begin query_end subject_begin
+           subject_end score evalue subject_description release_version) ->
+           structure: parameter "id" of String, parameter "subject_db" of
+           String, parameter "release_version" of String, parameter
+           "subject_description" of String, parameter "query_begin" of Long,
+           parameter "query_end" of Long, parameter "subject_begin" of Long,
+           parameter "subject_end" of Long, parameter "score" of Double,
+           parameter "evalue" of Double, parameter "aliases" of list of
+           String, parameter "orthologs" of list of tuple of size 2: String,
+           Double, parameter "annotations" of list of type "annotation" (a
+           notation by a curator of the genome object) -> tuple of size 3:
+           parameter "comment" of String, parameter "annotator" of String,
+           parameter "annotation_time" of Double, parameter "subsystem_data"
+           of list of type "subsystem_data" (Structure for subsystem data
+           (from CDMI API)) -> tuple of size 3: parameter "subsystem" of
+           String, parameter "variant" of String, parameter "role" of String,
+           parameter "regulon_data" of list of type "regulon_data" (Structure
+           for regulon data (from CDMI API)) -> tuple of size 3: parameter
+           "regulon_id" of String, parameter "regulon_set" of list of type
+           "Feature_id" (KBase Feature ID @id external), parameter "tfs" of
+           list of type "Feature_id" (KBase Feature ID @id external),
+           parameter "atomic_regulons" of list of type "atomic_regulon"
+           (Structure for an atomic regulon (from CDMI API)) -> tuple of size
+           2: parameter "atomic_regulon_id" of String, parameter
+           "atomic_regulon_size" of Long, parameter "coexpressed_fids" of
+           list of type "coexpressed_fid" (Structure for coexpressed fids
+           (from CDMI API)) -> tuple of size 2: parameter "scored_fid" of
+           type "Feature_id" (KBase Feature ID @id external), parameter
+           "score" of Double, parameter "co_occurring_fids" of list of type
+           "co_occurring_fid" (Structure for co-occurring fids (from CDMI
+           API)) -> tuple of size 2: parameter "scored_fid" of type
+           "Feature_id" (KBase Feature ID @id external), parameter "score" of
+           Double, parameter "quality" of type "Feature_quality_measure"
+           (@optional weighted_hit_count hit_count existence_priority
+           overlap_rules pyrrolysylprotein truncated_begin truncated_end
+           existence_confidence frameshifted selenoprotein) -> structure:
+           parameter "truncated_begin" of type "Bool", parameter
+           "truncated_end" of type "Bool", parameter "existence_confidence"
+           of Double, parameter "frameshifted" of type "Bool", parameter
+           "selenoprotein" of type "Bool", parameter "pyrrolysylprotein" of
+           type "Bool", parameter "overlap_rules" of list of String,
+           parameter "existence_priority" of Double, parameter "hit_count" of
+           Double, parameter "weighted_hit_count" of Double, parameter
+           "feature_creation_event" of type "Analysis_event" (@optional
+           tool_name execution_time parameters hostname) -> structure:
+           parameter "id" of type "Analysis_event_id", parameter "tool_name"
+           of String, parameter "execution_time" of Double, parameter
+           "parameters" of list of String, parameter "hostname" of String,
+           parameter "contigset_ref" of type "ContigSet_ref" (Reference to a
+           ContigSet object containing the contigs for this genome in the
+           workspace @id ws KBaseGenomes.ContigSet), parameter "assembly_ref"
+           of type "Assembly_ref" (Reference to an Assembly object in the
+           workspace @id ws KBaseGenomeAnnotations.Assembly), parameter
+           "quality" of type "Genome_quality_measure" (@optional
+           frameshift_error_rate sequence_error_rate) -> structure: parameter
+           "frameshift_error_rate" of Double, parameter "sequence_error_rate"
+           of Double, parameter "close_genomes" of list of type
+           "Close_genome" (@optional genome closeness_measure) -> structure:
+           parameter "genome" of type "Genome_id" (KBase genome ID @id kb),
+           parameter "closeness_measure" of Double, parameter
+           "analysis_events" of list of type "Analysis_event" (@optional
+           tool_name execution_time parameters hostname) -> structure:
+           parameter "id" of type "Analysis_event_id", parameter "tool_name"
+           of String, parameter "execution_time" of Double, parameter
+           "parameters" of list of String, parameter "hostname" of String,
+           parameter "hidden" of type "boolean" (A boolean - 0 for false, 1
+           for true. @range (0, 1)), parameter "provenance" of list of type
+           "ProvenanceAction" (A provenance action. A provenance action (PA)
+           is an action taken while transforming one data object to another.
+           There may be several PAs taken in series. A PA is typically
+           running a script, running an api command, etc. All of the
+           following fields are optional, but more information provided
+           equates to better data provenance. resolved_ws_objects should
+           never be set by the user; it is set by the workspace service when
+           returning data. On input, only one of the time or epoch may be
+           supplied. Both are supplied on output. The maximum size of the
+           entire provenance object, including all actions, is 1MB. timestamp
+           time - the time the action was started epoch epoch - the time the
+           action was started. string caller - the name or id of the invoker
+           of this provenance action. In most cases, this will be the same
+           for all PAs. string service - the name of the service that
+           performed this action. string service_ver - the version of the
+           service that performed this action. string method - the method of
+           the service that performed this action. list<UnspecifiedObject>
+           method_params - the parameters of the method that performed this
+           action. If an object in the parameters is a workspace object, also
+           put the object reference in the input_ws_object list. string
+           script - the name of the script that performed this action. string
+           script_ver - the version of the script that performed this action.
+           string script_command_line - the command line provided to the
+           script that performed this action. If workspace objects were
+           provided in the command line, also put the object reference in the
+           input_ws_object list. list<obj_ref> input_ws_objects - the
+           workspace objects that were used as input to this action;
+           typically these will also be present as parts of the method_params
+           or the script_command_line arguments. list<obj_ref>
+           resolved_ws_objects - the workspace objects ids from
+           input_ws_objects resolved to permanent workspace object references
+           by the workspace service. list<string> intermediate_incoming - if
+           the previous action produced output that 1) was not stored in a
+           referrable way, and 2) is used as input for this action, provide
+           it with an arbitrary and unique ID here, in the order of the input
+           arguments to this action. These IDs can be used in the
+           method_params argument. list<string> intermediate_outgoing - if
+           this action produced output that 1) was not stored in a referrable
+           way, and 2) is used as input for the next action, provide it with
+           an arbitrary and unique ID here, in the order of the output values
+           from this action. These IDs can be used in the
+           intermediate_incoming argument in the next action.
+           list<ExternalDataUnit> external_data - data external to the
+           workspace that was either imported to the workspace or used to
+           create a workspace object. list<SubAction> subactions - the
+           subactions taken as a part of this action. mapping<string, string>
+           custom - user definable custom provenance fields and their values.
+           string description - a free text description of this action.) ->
+           structure: parameter "time" of type "timestamp" (A time in the
+           format YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
+           (representing the UTC timezone) or the difference in time to UTC
+           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
+           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
+           time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
+           since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "caller"
+           of String, parameter "service" of String, parameter "service_ver"
+           of String, parameter "method" of String, parameter "method_params"
+           of list of unspecified object, parameter "script" of String,
+           parameter "script_ver" of String, parameter "script_command_line"
+           of String, parameter "input_ws_objects" of list of type "obj_ref"
+           (A string that uniquely identifies an object in the workspace
+           service. There are two ways to uniquely identify an object in one
+           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
+           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
+           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
+           version of an object with id 567 in a workspace with id 23. In all
+           cases, if the version number is omitted, the latest version of the
+           object is assumed.), parameter "resolved_ws_objects" of list of
+           type "obj_ref" (A string that uniquely identifies an object in the
+           workspace service. There are two ways to uniquely identify an
+           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
+           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
+           the third version of an object called MyFirstObject in the
+           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
+           first version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
+           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
+           version of an object with id 567 in a workspace with id 23. In all
+           cases, if the version number is omitted, the latest version of the
+           object is assumed.), parameter "intermediate_incoming" of list of
+           String, parameter "intermediate_outgoing" of list of String,
+           parameter "external_data" of list of type "ExternalDataUnit" (An
+           external data unit. A piece of data from a source outside the
+           Workspace. On input, only one of the resource_release_date or
+           resource_release_epoch may be supplied. Both are supplied on
+           output. string resource_name - the name of the resource, for
+           example JGI. string resource_url - the url of the resource, for
+           example http://genome.jgi.doe.gov string resource_version -
+           version of the resource timestamp resource_release_date - the
+           release date of the resource epoch resource_release_epoch - the
+           release date of the resource string data_url - the url of the
+           data, for example
+           http://genome.jgi.doe.gov/pages/dynamicOrganismDownload.jsf?
+           organism=BlaspURHD0036 string data_id - the id of the data, for
+           example 7625.2.79179.AGTTCC.adnq.fastq.gz string description - a
+           free text description of the data.) -> structure: parameter
+           "resource_name" of String, parameter "resource_url" of String,
+           parameter "resource_version" of String, parameter
+           "resource_release_date" of type "timestamp" (A time in the format
+           YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
+           (representing the UTC timezone) or the difference in time to UTC
+           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
+           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
+           time)), parameter "resource_release_epoch" of type "epoch" (A Unix
+           epoch (the time since 00:00:00 1/1/1970 UTC) in milliseconds.),
+           parameter "data_url" of String, parameter "data_id" of String,
+           parameter "description" of String, parameter "subactions" of list
+           of type "SubAction" (Information about a subaction that is invoked
+           by a provenance action. A provenance action (PA) may invoke
+           subactions (SA), e.g. calling a separate piece of code, a service,
+           or a script. In most cases these calls are the same from PA to PA
+           and so do not need to be listed in the provenance since providing
+           information about the PA alone provides reproducibility. In some
+           cases, however, SAs may change over time, such that invoking the
+           same PA with the same parameters may produce different results.
+           For example, if a PA calls a remote server, that server may be
+           updated between a PA invoked on day T and another PA invoked on
+           day T+1. The SubAction structure allows for specifying information
+           about SAs that may dynamically change from PA invocation to PA
+           invocation. string name - the name of the SA. string ver - the
+           version of SA. string code_url - a url pointing to the SA's
+           codebase. string commit - a version control commit ID for the SA.
+           string endpoint_url - a url pointing to the access point for the
+           SA - a server url, for instance.) -> structure: parameter "name"
+           of String, parameter "ver" of String, parameter "code_url" of
+           String, parameter "commit" of String, parameter "endpoint_url" of
+           String, parameter "custom" of mapping from String to String,
+           parameter "description" of String
+        :returns: instance of type "SaveLegacyGenomeResult" -> structure:
+           parameter "info" of list of type "object_info" (Information about
+           an object, including user provided metadata. obj_id objid - the
+           numerical id of the object. obj_name name - the name of the
+           object. type_string type - the type of the object. timestamp
+           save_date - the save date of the object. obj_ver ver - the version
+           of the object. username saved_by - the user that saved or copied
+           the object. ws_id wsid - the workspace containing the object.
+           ws_name workspace - the workspace containing the object. string
+           chsum - the md5 checksum of the object. int size - the size of the
+           object in bytes. usermeta meta - arbitrary user-supplied metadata
+           about the object.) -> tuple of size 11: parameter "objid" of type
+           "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "name" of type "obj_name" (A string used as a name for
+           an object. Any string consisting of alphanumeric characters and
+           the characters |._- that is not an integer is acceptable.),
+           parameter "type" of type "type_string" (A type string. Specifies
+           the type and its version in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "save_date" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "version" of Long,
+           parameter "saved_by" of type "username" (Login name of a KBase
+           user account.), parameter "wsid" of type "ws_id" (The unique,
+           permanent numerical ID of a workspace.), parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "chsum" of String, parameter
+           "size" of Long, parameter "meta" of type "usermeta" (User provided
+           metadata about an object. Arbitrary key-value pairs provided by
+           the user.) -> mapping from String to String
+        """
+        return self._client.call_method(
+            'GenomeAnnotationAPI.save_one_legacy_genome',
+            [params], self._service_ver, context)
+
     def status(self, context=None):
         return self._client.call_method('GenomeAnnotationAPI.status',
                                         [], self._service_ver, context)

--- a/lib/GenomeAnnotationAPI/GenomeAnnotationAPIClient.py
+++ b/lib/GenomeAnnotationAPI/GenomeAnnotationAPIClient.py
@@ -502,11 +502,14 @@ class GenomeAnnotationAPI(object):
         """
         :param params: instance of type "GetLegacyGenomeParams" -> structure:
            parameter "genomes" of list of type "LegacyGenomeSelector" ->
-           structure: parameter "ref" of String, parameter "included" of list
-           of String, parameter "ref_path_to_genome" of list of String,
-           parameter "ignore_errors" of type "boolean" (A boolean - 0 for
-           false, 1 for true. @range (0, 1)), parameter "no_data" of type
-           "boolean" (A boolean - 0 for false, 1 for true. @range (0, 1))
+           structure: parameter "ref" of String, parameter
+           "included_feature_position_index" of list of Long, parameter
+           "ref_path_to_genome" of list of String, parameter
+           "included_fields" of list of String, parameter
+           "included_feature_fields" of list of String, parameter
+           "ignore_errors" of type "boolean" (A boolean - 0 for false, 1 for
+           true. @range (0, 1)), parameter "no_data" of type "boolean" (A
+           boolean - 0 for false, 1 for true. @range (0, 1))
         :returns: instance of type "LegacyGenomeData" (todo: import Genome
            type and use it here) -> structure: parameter "data" of type
            "Genome" (Genome object holds much of the data relevant for a
@@ -847,8 +850,11 @@ class GenomeAnnotationAPI(object):
            2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
            time) 2013-04-03T08:56:32Z (UTC time)), parameter "epoch" of type
            "epoch" (A Unix epoch (the time since 00:00:00 1/1/1970 UTC) in
-           milliseconds.), parameter "handle_error" of String, parameter
-           "handle_stacktrace" of String
+           milliseconds.), parameter "refs" of list of String, parameter
+           "extracted_ids" of mapping from type "id_type" (An id type (e.g.
+           from a typespec @id annotation: @id [idtype])) to list of type
+           "extracted_id" (An id extracted from an object.), parameter
+           "handle_error" of String, parameter "handle_stacktrace" of String
         """
         return self._client.call_method(
             'GenomeAnnotationAPI.get_legacy_genome',

--- a/lib/GenomeAnnotationAPI/GenomeAnnotationAPIImpl.py
+++ b/lib/GenomeAnnotationAPI/GenomeAnnotationAPIImpl.py
@@ -4,6 +4,9 @@ from doekbase.data_api.annotation.genome_annotation.api import GenomeAnnotationA
 from doekbase.data_api import cache
 import logging
 from biokbase.workspace.client import Workspace
+
+from GenomeAnnotationAPI.LegacyGenomeInterface import LegacyGenomeInterface
+
 #END_HEADER
 
 
@@ -24,7 +27,7 @@ class GenomeAnnotationAPI:
     #########################################
     VERSION = "0.1.1"
     GIT_URL = "git@github.com:kbase/genome_annotation_api"
-    GIT_COMMIT_HASH = "c2c17451723015693759391051cb9d1885c9d87d"
+    GIT_COMMIT_HASH = "f4e62ffe79e0a85d74f1e6770c6217a6ee73548e"
     
     #BEGIN_CLASS_HEADER
     def _migrate_property_internal(self, from_dict, to_dict, prop_name, to_prop_name = None):
@@ -1029,11 +1032,14 @@ class GenomeAnnotationAPI:
         """
         :param params: instance of type "GetLegacyGenomeParams" -> structure:
            parameter "genomes" of list of type "LegacyGenomeSelector" ->
-           structure: parameter "ref" of String, parameter "included" of list
-           of String, parameter "ref_path_to_genome" of list of String,
-           parameter "ignore_errors" of type "boolean" (A boolean - 0 for
-           false, 1 for true. @range (0, 1)), parameter "no_data" of type
-           "boolean" (A boolean - 0 for false, 1 for true. @range (0, 1))
+           structure: parameter "ref" of String, parameter
+           "included_feature_position_index" of list of Long, parameter
+           "ref_path_to_genome" of list of String, parameter
+           "included_fields" of list of String, parameter
+           "included_feature_fields" of list of String, parameter
+           "ignore_errors" of type "boolean" (A boolean - 0 for false, 1 for
+           true. @range (0, 1)), parameter "no_data" of type "boolean" (A
+           boolean - 0 for false, 1 for true. @range (0, 1))
         :returns: instance of type "LegacyGenomeData" (todo: import Genome
            type and use it here) -> structure: parameter "data" of type
            "Genome" (Genome object holds much of the data relevant for a
@@ -1374,12 +1380,18 @@ class GenomeAnnotationAPI:
            2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
            time) 2013-04-03T08:56:32Z (UTC time)), parameter "epoch" of type
            "epoch" (A Unix epoch (the time since 00:00:00 1/1/1970 UTC) in
-           milliseconds.), parameter "handle_error" of String, parameter
-           "handle_stacktrace" of String
+           milliseconds.), parameter "refs" of list of String, parameter
+           "extracted_ids" of mapping from type "id_type" (An id type (e.g.
+           from a typespec @id annotation: @id [idtype])) to list of type
+           "extracted_id" (An id extracted from an object.), parameter
+           "handle_error" of String, parameter "handle_stacktrace" of String
         """
         # ctx is the context object
         # return variables are: data
         #BEGIN get_legacy_genome
+        ws = Workspace(self.services['workspace_service_url'], token=ctx['token'])
+        legacy_genome_interface = LegacyGenomeInterface(ws)
+        data = legacy_genome_interface.get_legacy_genome(ctx, params)
         #END get_legacy_genome
 
         # At some point might do deeper type checking...
@@ -1731,6 +1743,10 @@ class GenomeAnnotationAPI:
         # ctx is the context object
         # return variables are: result
         #BEGIN save_one_legacy_genome
+        raise ValueError('Not yet supported')
+        ws = Workspace(self.services['workspace_service_url'], token=ctx['token'])
+        legacy_genome_interface = LegacyGenomeInterface(ws)
+        result = legacy_genome_interface.save_one_legacy_genome(ctx, params)
         #END save_one_legacy_genome
 
         # At some point might do deeper type checking...

--- a/lib/GenomeAnnotationAPI/GenomeAnnotationAPIImpl.py
+++ b/lib/GenomeAnnotationAPI/GenomeAnnotationAPIImpl.py
@@ -13,7 +13,7 @@ class GenomeAnnotationAPI:
     GenomeAnnotationAPI
 
     Module Description:
-    A KBase module: GenomeAnnotationAPI
+    
     '''
 
     ######## WARNING FOR GEVENT USERS #######
@@ -23,8 +23,8 @@ class GenomeAnnotationAPI:
     # the latter method is running.
     #########################################
     VERSION = "0.1.1"
-    GIT_URL = "https://github.com/rsutormin/genome_annotation_api"
-    GIT_COMMIT_HASH = "71e37b2b56471ca768261a32d431f4a6013673ec"
+    GIT_URL = "git@github.com:kbase/genome_annotation_api"
+    GIT_COMMIT_HASH = "c2c17451723015693759391051cb9d1885c9d87d"
     
     #BEGIN_CLASS_HEADER
     def _migrate_property_internal(self, from_dict, to_dict, prop_name, to_prop_name = None):
@@ -1008,6 +1008,721 @@ class GenomeAnnotationAPI:
                              'returnVal is not type dict as required.')
         # return the results
         return [returnVal]
+
+    def get_legacy_genome(self, ctx, params):
+        """
+        :param params: instance of type "GetLegacyGenomeParams" -> structure:
+           parameter "genomes" of list of type "LegacyGenomeSelector" ->
+           structure: parameter "ref" of String, parameter "included" of list
+           of String, parameter "ref_path_to_genome" of list of String,
+           parameter "ignore_errors" of type "boolean" (A boolean - 0 for
+           false, 1 for true. @range (0, 1)), parameter "no_data" of type
+           "boolean" (A boolean - 0 for false, 1 for true. @range (0, 1))
+        :returns: instance of type "LegacyGenomeData" (todo: import Genome
+           type and use it here) -> structure: parameter "data" of type
+           "Genome" (Genome object holds much of the data relevant for a
+           genome in KBase Genome publications should be papers about the
+           genome, not papers about certain features of the genome (which go
+           into the Feature object) Should the Genome object have a list of
+           feature ids? (in addition to having a list of feature_refs) Should
+           the Genome object contain a list of contig_ids too? @optional
+           assembly_ref quality close_genomes analysis_events features
+           source_id source contigs contig_ids publications md5 taxonomy
+           gc_content complete dna_size num_contigs contig_lengths
+           contigset_ref @metadata ws gc_content as GC content @metadata ws
+           taxonomy as Taxonomy @metadata ws md5 as MD5 @metadata ws dna_size
+           as Size @metadata ws genetic_code as Genetic code @metadata ws
+           domain as Domain @metadata ws source_id as Source ID @metadata ws
+           source as Source @metadata ws scientific_name as Name @metadata ws
+           length(close_genomes) as Close genomes @metadata ws
+           length(features) as Number features @metadata ws num_contigs as
+           Number contigs) -> structure: parameter "id" of type "Genome_id"
+           (KBase genome ID @id kb), parameter "scientific_name" of String,
+           parameter "domain" of String, parameter "genetic_code" of Long,
+           parameter "dna_size" of Long, parameter "num_contigs" of Long,
+           parameter "contigs" of list of type "Contig" (Type spec for a
+           "Contig" subobject in the "ContigSet" object Contig_id id - ID of
+           contig in contigset string md5 - unique hash of contig sequence
+           string sequence - sequence of the contig string description -
+           Description of the contig (e.g. everything after the ID in a FASTA
+           file) @optional length md5 genetic_code cell_compartment
+           replicon_geometry replicon_type name description complete) ->
+           structure: parameter "id" of type "Contig_id" (ContigSet contig ID
+           @id external), parameter "length" of Long, parameter "md5" of
+           String, parameter "sequence" of String, parameter "genetic_code"
+           of Long, parameter "cell_compartment" of String, parameter
+           "replicon_type" of String, parameter "replicon_geometry" of
+           String, parameter "name" of String, parameter "description" of
+           String, parameter "complete" of type "Bool", parameter
+           "contig_lengths" of list of Long, parameter "contig_ids" of list
+           of type "Contig_id" (ContigSet contig ID @id external), parameter
+           "source" of String, parameter "source_id" of type "source_id"
+           (Reference to a source_id @id external), parameter "md5" of
+           String, parameter "taxonomy" of String, parameter "gc_content" of
+           Double, parameter "complete" of Long, parameter "publications" of
+           list of type "publication" (Structure for a publication (from ER
+           API) also want to capture authors, journal name (not in ER)) ->
+           tuple of size 7: parameter "id" of Long, parameter "source_db" of
+           String, parameter "article_title" of String, parameter "link" of
+           String, parameter "pubdate" of String, parameter "authors" of
+           String, parameter "journal_name" of String, parameter "features"
+           of list of type "Feature" (Structure for a single feature of a
+           genome Should genome_id contain the genome_id in the Genome
+           object, the workspace id of the Genome object, a genomeref,
+           something else? Should sequence be in separate objects too? We may
+           want to add additional fields for other CDM functions (e.g.,
+           atomic regulons, coexpressed fids, co_occurring fids,...)
+           @optional orthologs quality feature_creation_event md5 location
+           function ontology_terms protein_translation protein_families
+           subsystems publications subsystem_data aliases annotations
+           regulon_data atomic_regulons coexpressed_fids co_occurring_fids
+           dna_sequence protein_translation_length dna_sequence_length) ->
+           structure: parameter "id" of type "Feature_id" (KBase Feature ID
+           @id external), parameter "location" of list of tuple of size 4:
+           type "Contig_id" (ContigSet contig ID @id external), Long, String,
+           Long, parameter "type" of String, parameter "function" of String,
+           parameter "ontology_terms" of mapping from String to mapping from
+           String to type "OntologyData" -> structure: parameter "id" of
+           String, parameter "ontology_ref" of String, parameter
+           "term_lineage" of list of String, parameter "term_name" of String,
+           parameter "evidence" of list of type "OntologyEvidence" (@optional
+           translation_provenance alignment_evidence) -> structure: parameter
+           "method" of String, parameter "method_version" of String,
+           parameter "timestamp" of String, parameter
+           "translation_provenance" of tuple of size 3: parameter
+           "ontologytranslation_ref" of String, parameter "namespace" of
+           String, parameter "source_term" of String, parameter
+           "alignment_evidence" of list of tuple of size 4: parameter "start"
+           of Long, parameter "stop" of Long, parameter "align_length" of
+           Long, parameter "identify" of Double, parameter "md5" of String,
+           parameter "protein_translation" of String, parameter
+           "dna_sequence" of String, parameter "protein_translation_length"
+           of Long, parameter "dna_sequence_length" of Long, parameter
+           "publications" of list of type "publication" (Structure for a
+           publication (from ER API) also want to capture authors, journal
+           name (not in ER)) -> tuple of size 7: parameter "id" of Long,
+           parameter "source_db" of String, parameter "article_title" of
+           String, parameter "link" of String, parameter "pubdate" of String,
+           parameter "authors" of String, parameter "journal_name" of String,
+           parameter "subsystems" of list of String, parameter
+           "protein_families" of list of type "ProteinFamily" (Structure for
+           a protein family @optional query_begin query_end subject_begin
+           subject_end score evalue subject_description release_version) ->
+           structure: parameter "id" of String, parameter "subject_db" of
+           String, parameter "release_version" of String, parameter
+           "subject_description" of String, parameter "query_begin" of Long,
+           parameter "query_end" of Long, parameter "subject_begin" of Long,
+           parameter "subject_end" of Long, parameter "score" of Double,
+           parameter "evalue" of Double, parameter "aliases" of list of
+           String, parameter "orthologs" of list of tuple of size 2: String,
+           Double, parameter "annotations" of list of type "annotation" (a
+           notation by a curator of the genome object) -> tuple of size 3:
+           parameter "comment" of String, parameter "annotator" of String,
+           parameter "annotation_time" of Double, parameter "subsystem_data"
+           of list of type "subsystem_data" (Structure for subsystem data
+           (from CDMI API)) -> tuple of size 3: parameter "subsystem" of
+           String, parameter "variant" of String, parameter "role" of String,
+           parameter "regulon_data" of list of type "regulon_data" (Structure
+           for regulon data (from CDMI API)) -> tuple of size 3: parameter
+           "regulon_id" of String, parameter "regulon_set" of list of type
+           "Feature_id" (KBase Feature ID @id external), parameter "tfs" of
+           list of type "Feature_id" (KBase Feature ID @id external),
+           parameter "atomic_regulons" of list of type "atomic_regulon"
+           (Structure for an atomic regulon (from CDMI API)) -> tuple of size
+           2: parameter "atomic_regulon_id" of String, parameter
+           "atomic_regulon_size" of Long, parameter "coexpressed_fids" of
+           list of type "coexpressed_fid" (Structure for coexpressed fids
+           (from CDMI API)) -> tuple of size 2: parameter "scored_fid" of
+           type "Feature_id" (KBase Feature ID @id external), parameter
+           "score" of Double, parameter "co_occurring_fids" of list of type
+           "co_occurring_fid" (Structure for co-occurring fids (from CDMI
+           API)) -> tuple of size 2: parameter "scored_fid" of type
+           "Feature_id" (KBase Feature ID @id external), parameter "score" of
+           Double, parameter "quality" of type "Feature_quality_measure"
+           (@optional weighted_hit_count hit_count existence_priority
+           overlap_rules pyrrolysylprotein truncated_begin truncated_end
+           existence_confidence frameshifted selenoprotein) -> structure:
+           parameter "truncated_begin" of type "Bool", parameter
+           "truncated_end" of type "Bool", parameter "existence_confidence"
+           of Double, parameter "frameshifted" of type "Bool", parameter
+           "selenoprotein" of type "Bool", parameter "pyrrolysylprotein" of
+           type "Bool", parameter "overlap_rules" of list of String,
+           parameter "existence_priority" of Double, parameter "hit_count" of
+           Double, parameter "weighted_hit_count" of Double, parameter
+           "feature_creation_event" of type "Analysis_event" (@optional
+           tool_name execution_time parameters hostname) -> structure:
+           parameter "id" of type "Analysis_event_id", parameter "tool_name"
+           of String, parameter "execution_time" of Double, parameter
+           "parameters" of list of String, parameter "hostname" of String,
+           parameter "contigset_ref" of type "ContigSet_ref" (Reference to a
+           ContigSet object containing the contigs for this genome in the
+           workspace @id ws KBaseGenomes.ContigSet), parameter "assembly_ref"
+           of type "Assembly_ref" (Reference to an Assembly object in the
+           workspace @id ws KBaseGenomeAnnotations.Assembly), parameter
+           "quality" of type "Genome_quality_measure" (@optional
+           frameshift_error_rate sequence_error_rate) -> structure: parameter
+           "frameshift_error_rate" of Double, parameter "sequence_error_rate"
+           of Double, parameter "close_genomes" of list of type
+           "Close_genome" (@optional genome closeness_measure) -> structure:
+           parameter "genome" of type "Genome_id" (KBase genome ID @id kb),
+           parameter "closeness_measure" of Double, parameter
+           "analysis_events" of list of type "Analysis_event" (@optional
+           tool_name execution_time parameters hostname) -> structure:
+           parameter "id" of type "Analysis_event_id", parameter "tool_name"
+           of String, parameter "execution_time" of Double, parameter
+           "parameters" of list of String, parameter "hostname" of String,
+           parameter "info" of type "object_info" (Information about an
+           object, including user provided metadata. obj_id objid - the
+           numerical id of the object. obj_name name - the name of the
+           object. type_string type - the type of the object. timestamp
+           save_date - the save date of the object. obj_ver ver - the version
+           of the object. username saved_by - the user that saved or copied
+           the object. ws_id wsid - the workspace containing the object.
+           ws_name workspace - the workspace containing the object. string
+           chsum - the md5 checksum of the object. int size - the size of the
+           object in bytes. usermeta meta - arbitrary user-supplied metadata
+           about the object.) -> tuple of size 11: parameter "objid" of type
+           "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "name" of type "obj_name" (A string used as a name for
+           an object. Any string consisting of alphanumeric characters and
+           the characters |._- that is not an integer is acceptable.),
+           parameter "type" of type "type_string" (A type string. Specifies
+           the type and its version in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "save_date" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "version" of Long,
+           parameter "saved_by" of type "username" (Login name of a KBase
+           user account.), parameter "wsid" of type "ws_id" (The unique,
+           permanent numerical ID of a workspace.), parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "chsum" of String, parameter
+           "size" of Long, parameter "meta" of type "usermeta" (User provided
+           metadata about an object. Arbitrary key-value pairs provided by
+           the user.) -> mapping from String to String, parameter
+           "provenance" of list of type "ProvenanceAction" (A provenance
+           action. A provenance action (PA) is an action taken while
+           transforming one data object to another. There may be several PAs
+           taken in series. A PA is typically running a script, running an
+           api command, etc. All of the following fields are optional, but
+           more information provided equates to better data provenance.
+           resolved_ws_objects should never be set by the user; it is set by
+           the workspace service when returning data. On input, only one of
+           the time or epoch may be supplied. Both are supplied on output.
+           The maximum size of the entire provenance object, including all
+           actions, is 1MB. timestamp time - the time the action was started
+           epoch epoch - the time the action was started. string caller - the
+           name or id of the invoker of this provenance action. In most
+           cases, this will be the same for all PAs. string service - the
+           name of the service that performed this action. string service_ver
+           - the version of the service that performed this action. string
+           method - the method of the service that performed this action.
+           list<UnspecifiedObject> method_params - the parameters of the
+           method that performed this action. If an object in the parameters
+           is a workspace object, also put the object reference in the
+           input_ws_object list. string script - the name of the script that
+           performed this action. string script_ver - the version of the
+           script that performed this action. string script_command_line -
+           the command line provided to the script that performed this
+           action. If workspace objects were provided in the command line,
+           also put the object reference in the input_ws_object list.
+           list<obj_ref> input_ws_objects - the workspace objects that were
+           used as input to this action; typically these will also be present
+           as parts of the method_params or the script_command_line
+           arguments. list<obj_ref> resolved_ws_objects - the workspace
+           objects ids from input_ws_objects resolved to permanent workspace
+           object references by the workspace service. list<string>
+           intermediate_incoming - if the previous action produced output
+           that 1) was not stored in a referrable way, and 2) is used as
+           input for this action, provide it with an arbitrary and unique ID
+           here, in the order of the input arguments to this action. These
+           IDs can be used in the method_params argument. list<string>
+           intermediate_outgoing - if this action produced output that 1) was
+           not stored in a referrable way, and 2) is used as input for the
+           next action, provide it with an arbitrary and unique ID here, in
+           the order of the output values from this action. These IDs can be
+           used in the intermediate_incoming argument in the next action.
+           list<ExternalDataUnit> external_data - data external to the
+           workspace that was either imported to the workspace or used to
+           create a workspace object. list<SubAction> subactions - the
+           subactions taken as a part of this action. mapping<string, string>
+           custom - user definable custom provenance fields and their values.
+           string description - a free text description of this action.) ->
+           structure: parameter "time" of type "timestamp" (A time in the
+           format YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
+           (representing the UTC timezone) or the difference in time to UTC
+           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
+           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
+           time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
+           since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "caller"
+           of String, parameter "service" of String, parameter "service_ver"
+           of String, parameter "method" of String, parameter "method_params"
+           of list of unspecified object, parameter "script" of String,
+           parameter "script_ver" of String, parameter "script_command_line"
+           of String, parameter "input_ws_objects" of list of type "obj_ref"
+           (A string that uniquely identifies an object in the workspace
+           service. There are two ways to uniquely identify an object in one
+           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
+           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
+           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
+           version of an object with id 567 in a workspace with id 23. In all
+           cases, if the version number is omitted, the latest version of the
+           object is assumed.), parameter "resolved_ws_objects" of list of
+           type "obj_ref" (A string that uniquely identifies an object in the
+           workspace service. There are two ways to uniquely identify an
+           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
+           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
+           the third version of an object called MyFirstObject in the
+           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
+           first version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
+           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
+           version of an object with id 567 in a workspace with id 23. In all
+           cases, if the version number is omitted, the latest version of the
+           object is assumed.), parameter "intermediate_incoming" of list of
+           String, parameter "intermediate_outgoing" of list of String,
+           parameter "external_data" of list of type "ExternalDataUnit" (An
+           external data unit. A piece of data from a source outside the
+           Workspace. On input, only one of the resource_release_date or
+           resource_release_epoch may be supplied. Both are supplied on
+           output. string resource_name - the name of the resource, for
+           example JGI. string resource_url - the url of the resource, for
+           example http://genome.jgi.doe.gov string resource_version -
+           version of the resource timestamp resource_release_date - the
+           release date of the resource epoch resource_release_epoch - the
+           release date of the resource string data_url - the url of the
+           data, for example
+           http://genome.jgi.doe.gov/pages/dynamicOrganismDownload.jsf?
+           organism=BlaspURHD0036 string data_id - the id of the data, for
+           example 7625.2.79179.AGTTCC.adnq.fastq.gz string description - a
+           free text description of the data.) -> structure: parameter
+           "resource_name" of String, parameter "resource_url" of String,
+           parameter "resource_version" of String, parameter
+           "resource_release_date" of type "timestamp" (A time in the format
+           YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
+           (representing the UTC timezone) or the difference in time to UTC
+           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
+           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
+           time)), parameter "resource_release_epoch" of type "epoch" (A Unix
+           epoch (the time since 00:00:00 1/1/1970 UTC) in milliseconds.),
+           parameter "data_url" of String, parameter "data_id" of String,
+           parameter "description" of String, parameter "subactions" of list
+           of type "SubAction" (Information about a subaction that is invoked
+           by a provenance action. A provenance action (PA) may invoke
+           subactions (SA), e.g. calling a separate piece of code, a service,
+           or a script. In most cases these calls are the same from PA to PA
+           and so do not need to be listed in the provenance since providing
+           information about the PA alone provides reproducibility. In some
+           cases, however, SAs may change over time, such that invoking the
+           same PA with the same parameters may produce different results.
+           For example, if a PA calls a remote server, that server may be
+           updated between a PA invoked on day T and another PA invoked on
+           day T+1. The SubAction structure allows for specifying information
+           about SAs that may dynamically change from PA invocation to PA
+           invocation. string name - the name of the SA. string ver - the
+           version of SA. string code_url - a url pointing to the SA's
+           codebase. string commit - a version control commit ID for the SA.
+           string endpoint_url - a url pointing to the access point for the
+           SA - a server url, for instance.) -> structure: parameter "name"
+           of String, parameter "ver" of String, parameter "code_url" of
+           String, parameter "commit" of String, parameter "endpoint_url" of
+           String, parameter "custom" of mapping from String to String,
+           parameter "description" of String, parameter "creator" of String,
+           parameter "orig_wsid" of String, parameter "copied" of String,
+           parameter "copy_source_inaccessible" of type "boolean" (A boolean
+           - 0 for false, 1 for true. @range (0, 1)), parameter "created" of
+           type "timestamp" (A time in the format YYYY-MM-DDThh:mm:ssZ, where
+           Z is either the character Z (representing the UTC timezone) or the
+           difference in time to UTC in the format +/-HHMM, eg:
+           2012-12-17T23:24:06-0500 (EST time) 2013-04-03T08:56:32+0000 (UTC
+           time) 2013-04-03T08:56:32Z (UTC time)), parameter "epoch" of type
+           "epoch" (A Unix epoch (the time since 00:00:00 1/1/1970 UTC) in
+           milliseconds.), parameter "handle_error" of String, parameter
+           "handle_stacktrace" of String
+        """
+        # ctx is the context object
+        # return variables are: data
+        #BEGIN get_legacy_genome
+        #END get_legacy_genome
+
+        # At some point might do deeper type checking...
+        if not isinstance(data, dict):
+            raise ValueError('Method get_legacy_genome return value ' +
+                             'data is not type dict as required.')
+        # return the results
+        return [data]
+
+    def save_one_legacy_genome(self, ctx, params):
+        """
+        :param params: instance of type "SaveLegacyGenomeParams" ->
+           structure: parameter "workspace" of String, parameter "name" of
+           String, parameter "genomes" of list of type "LegacyGenomeSaveData"
+           -> structure: parameter "data" of type "Genome" (Genome object
+           holds much of the data relevant for a genome in KBase Genome
+           publications should be papers about the genome, not papers about
+           certain features of the genome (which go into the Feature object)
+           Should the Genome object have a list of feature ids? (in addition
+           to having a list of feature_refs) Should the Genome object contain
+           a list of contig_ids too? @optional assembly_ref quality
+           close_genomes analysis_events features source_id source contigs
+           contig_ids publications md5 taxonomy gc_content complete dna_size
+           num_contigs contig_lengths contigset_ref @metadata ws gc_content
+           as GC content @metadata ws taxonomy as Taxonomy @metadata ws md5
+           as MD5 @metadata ws dna_size as Size @metadata ws genetic_code as
+           Genetic code @metadata ws domain as Domain @metadata ws source_id
+           as Source ID @metadata ws source as Source @metadata ws
+           scientific_name as Name @metadata ws length(close_genomes) as
+           Close genomes @metadata ws length(features) as Number features
+           @metadata ws num_contigs as Number contigs) -> structure:
+           parameter "id" of type "Genome_id" (KBase genome ID @id kb),
+           parameter "scientific_name" of String, parameter "domain" of
+           String, parameter "genetic_code" of Long, parameter "dna_size" of
+           Long, parameter "num_contigs" of Long, parameter "contigs" of list
+           of type "Contig" (Type spec for a "Contig" subobject in the
+           "ContigSet" object Contig_id id - ID of contig in contigset string
+           md5 - unique hash of contig sequence string sequence - sequence of
+           the contig string description - Description of the contig (e.g.
+           everything after the ID in a FASTA file) @optional length md5
+           genetic_code cell_compartment replicon_geometry replicon_type name
+           description complete) -> structure: parameter "id" of type
+           "Contig_id" (ContigSet contig ID @id external), parameter "length"
+           of Long, parameter "md5" of String, parameter "sequence" of
+           String, parameter "genetic_code" of Long, parameter
+           "cell_compartment" of String, parameter "replicon_type" of String,
+           parameter "replicon_geometry" of String, parameter "name" of
+           String, parameter "description" of String, parameter "complete" of
+           type "Bool", parameter "contig_lengths" of list of Long, parameter
+           "contig_ids" of list of type "Contig_id" (ContigSet contig ID @id
+           external), parameter "source" of String, parameter "source_id" of
+           type "source_id" (Reference to a source_id @id external),
+           parameter "md5" of String, parameter "taxonomy" of String,
+           parameter "gc_content" of Double, parameter "complete" of Long,
+           parameter "publications" of list of type "publication" (Structure
+           for a publication (from ER API) also want to capture authors,
+           journal name (not in ER)) -> tuple of size 7: parameter "id" of
+           Long, parameter "source_db" of String, parameter "article_title"
+           of String, parameter "link" of String, parameter "pubdate" of
+           String, parameter "authors" of String, parameter "journal_name" of
+           String, parameter "features" of list of type "Feature" (Structure
+           for a single feature of a genome Should genome_id contain the
+           genome_id in the Genome object, the workspace id of the Genome
+           object, a genomeref, something else? Should sequence be in
+           separate objects too? We may want to add additional fields for
+           other CDM functions (e.g., atomic regulons, coexpressed fids,
+           co_occurring fids,...) @optional orthologs quality
+           feature_creation_event md5 location function ontology_terms
+           protein_translation protein_families subsystems publications
+           subsystem_data aliases annotations regulon_data atomic_regulons
+           coexpressed_fids co_occurring_fids dna_sequence
+           protein_translation_length dna_sequence_length) -> structure:
+           parameter "id" of type "Feature_id" (KBase Feature ID @id
+           external), parameter "location" of list of tuple of size 4: type
+           "Contig_id" (ContigSet contig ID @id external), Long, String,
+           Long, parameter "type" of String, parameter "function" of String,
+           parameter "ontology_terms" of mapping from String to mapping from
+           String to type "OntologyData" -> structure: parameter "id" of
+           String, parameter "ontology_ref" of String, parameter
+           "term_lineage" of list of String, parameter "term_name" of String,
+           parameter "evidence" of list of type "OntologyEvidence" (@optional
+           translation_provenance alignment_evidence) -> structure: parameter
+           "method" of String, parameter "method_version" of String,
+           parameter "timestamp" of String, parameter
+           "translation_provenance" of tuple of size 3: parameter
+           "ontologytranslation_ref" of String, parameter "namespace" of
+           String, parameter "source_term" of String, parameter
+           "alignment_evidence" of list of tuple of size 4: parameter "start"
+           of Long, parameter "stop" of Long, parameter "align_length" of
+           Long, parameter "identify" of Double, parameter "md5" of String,
+           parameter "protein_translation" of String, parameter
+           "dna_sequence" of String, parameter "protein_translation_length"
+           of Long, parameter "dna_sequence_length" of Long, parameter
+           "publications" of list of type "publication" (Structure for a
+           publication (from ER API) also want to capture authors, journal
+           name (not in ER)) -> tuple of size 7: parameter "id" of Long,
+           parameter "source_db" of String, parameter "article_title" of
+           String, parameter "link" of String, parameter "pubdate" of String,
+           parameter "authors" of String, parameter "journal_name" of String,
+           parameter "subsystems" of list of String, parameter
+           "protein_families" of list of type "ProteinFamily" (Structure for
+           a protein family @optional query_begin query_end subject_begin
+           subject_end score evalue subject_description release_version) ->
+           structure: parameter "id" of String, parameter "subject_db" of
+           String, parameter "release_version" of String, parameter
+           "subject_description" of String, parameter "query_begin" of Long,
+           parameter "query_end" of Long, parameter "subject_begin" of Long,
+           parameter "subject_end" of Long, parameter "score" of Double,
+           parameter "evalue" of Double, parameter "aliases" of list of
+           String, parameter "orthologs" of list of tuple of size 2: String,
+           Double, parameter "annotations" of list of type "annotation" (a
+           notation by a curator of the genome object) -> tuple of size 3:
+           parameter "comment" of String, parameter "annotator" of String,
+           parameter "annotation_time" of Double, parameter "subsystem_data"
+           of list of type "subsystem_data" (Structure for subsystem data
+           (from CDMI API)) -> tuple of size 3: parameter "subsystem" of
+           String, parameter "variant" of String, parameter "role" of String,
+           parameter "regulon_data" of list of type "regulon_data" (Structure
+           for regulon data (from CDMI API)) -> tuple of size 3: parameter
+           "regulon_id" of String, parameter "regulon_set" of list of type
+           "Feature_id" (KBase Feature ID @id external), parameter "tfs" of
+           list of type "Feature_id" (KBase Feature ID @id external),
+           parameter "atomic_regulons" of list of type "atomic_regulon"
+           (Structure for an atomic regulon (from CDMI API)) -> tuple of size
+           2: parameter "atomic_regulon_id" of String, parameter
+           "atomic_regulon_size" of Long, parameter "coexpressed_fids" of
+           list of type "coexpressed_fid" (Structure for coexpressed fids
+           (from CDMI API)) -> tuple of size 2: parameter "scored_fid" of
+           type "Feature_id" (KBase Feature ID @id external), parameter
+           "score" of Double, parameter "co_occurring_fids" of list of type
+           "co_occurring_fid" (Structure for co-occurring fids (from CDMI
+           API)) -> tuple of size 2: parameter "scored_fid" of type
+           "Feature_id" (KBase Feature ID @id external), parameter "score" of
+           Double, parameter "quality" of type "Feature_quality_measure"
+           (@optional weighted_hit_count hit_count existence_priority
+           overlap_rules pyrrolysylprotein truncated_begin truncated_end
+           existence_confidence frameshifted selenoprotein) -> structure:
+           parameter "truncated_begin" of type "Bool", parameter
+           "truncated_end" of type "Bool", parameter "existence_confidence"
+           of Double, parameter "frameshifted" of type "Bool", parameter
+           "selenoprotein" of type "Bool", parameter "pyrrolysylprotein" of
+           type "Bool", parameter "overlap_rules" of list of String,
+           parameter "existence_priority" of Double, parameter "hit_count" of
+           Double, parameter "weighted_hit_count" of Double, parameter
+           "feature_creation_event" of type "Analysis_event" (@optional
+           tool_name execution_time parameters hostname) -> structure:
+           parameter "id" of type "Analysis_event_id", parameter "tool_name"
+           of String, parameter "execution_time" of Double, parameter
+           "parameters" of list of String, parameter "hostname" of String,
+           parameter "contigset_ref" of type "ContigSet_ref" (Reference to a
+           ContigSet object containing the contigs for this genome in the
+           workspace @id ws KBaseGenomes.ContigSet), parameter "assembly_ref"
+           of type "Assembly_ref" (Reference to an Assembly object in the
+           workspace @id ws KBaseGenomeAnnotations.Assembly), parameter
+           "quality" of type "Genome_quality_measure" (@optional
+           frameshift_error_rate sequence_error_rate) -> structure: parameter
+           "frameshift_error_rate" of Double, parameter "sequence_error_rate"
+           of Double, parameter "close_genomes" of list of type
+           "Close_genome" (@optional genome closeness_measure) -> structure:
+           parameter "genome" of type "Genome_id" (KBase genome ID @id kb),
+           parameter "closeness_measure" of Double, parameter
+           "analysis_events" of list of type "Analysis_event" (@optional
+           tool_name execution_time parameters hostname) -> structure:
+           parameter "id" of type "Analysis_event_id", parameter "tool_name"
+           of String, parameter "execution_time" of Double, parameter
+           "parameters" of list of String, parameter "hostname" of String,
+           parameter "hidden" of type "boolean" (A boolean - 0 for false, 1
+           for true. @range (0, 1)), parameter "provenance" of list of type
+           "ProvenanceAction" (A provenance action. A provenance action (PA)
+           is an action taken while transforming one data object to another.
+           There may be several PAs taken in series. A PA is typically
+           running a script, running an api command, etc. All of the
+           following fields are optional, but more information provided
+           equates to better data provenance. resolved_ws_objects should
+           never be set by the user; it is set by the workspace service when
+           returning data. On input, only one of the time or epoch may be
+           supplied. Both are supplied on output. The maximum size of the
+           entire provenance object, including all actions, is 1MB. timestamp
+           time - the time the action was started epoch epoch - the time the
+           action was started. string caller - the name or id of the invoker
+           of this provenance action. In most cases, this will be the same
+           for all PAs. string service - the name of the service that
+           performed this action. string service_ver - the version of the
+           service that performed this action. string method - the method of
+           the service that performed this action. list<UnspecifiedObject>
+           method_params - the parameters of the method that performed this
+           action. If an object in the parameters is a workspace object, also
+           put the object reference in the input_ws_object list. string
+           script - the name of the script that performed this action. string
+           script_ver - the version of the script that performed this action.
+           string script_command_line - the command line provided to the
+           script that performed this action. If workspace objects were
+           provided in the command line, also put the object reference in the
+           input_ws_object list. list<obj_ref> input_ws_objects - the
+           workspace objects that were used as input to this action;
+           typically these will also be present as parts of the method_params
+           or the script_command_line arguments. list<obj_ref>
+           resolved_ws_objects - the workspace objects ids from
+           input_ws_objects resolved to permanent workspace object references
+           by the workspace service. list<string> intermediate_incoming - if
+           the previous action produced output that 1) was not stored in a
+           referrable way, and 2) is used as input for this action, provide
+           it with an arbitrary and unique ID here, in the order of the input
+           arguments to this action. These IDs can be used in the
+           method_params argument. list<string> intermediate_outgoing - if
+           this action produced output that 1) was not stored in a referrable
+           way, and 2) is used as input for the next action, provide it with
+           an arbitrary and unique ID here, in the order of the output values
+           from this action. These IDs can be used in the
+           intermediate_incoming argument in the next action.
+           list<ExternalDataUnit> external_data - data external to the
+           workspace that was either imported to the workspace or used to
+           create a workspace object. list<SubAction> subactions - the
+           subactions taken as a part of this action. mapping<string, string>
+           custom - user definable custom provenance fields and their values.
+           string description - a free text description of this action.) ->
+           structure: parameter "time" of type "timestamp" (A time in the
+           format YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
+           (representing the UTC timezone) or the difference in time to UTC
+           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
+           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
+           time)), parameter "epoch" of type "epoch" (A Unix epoch (the time
+           since 00:00:00 1/1/1970 UTC) in milliseconds.), parameter "caller"
+           of String, parameter "service" of String, parameter "service_ver"
+           of String, parameter "method" of String, parameter "method_params"
+           of list of unspecified object, parameter "script" of String,
+           parameter "script_ver" of String, parameter "script_command_line"
+           of String, parameter "input_ws_objects" of list of type "obj_ref"
+           (A string that uniquely identifies an object in the workspace
+           service. There are two ways to uniquely identify an object in one
+           string: "[ws_name or id]/[obj_name or id]/[obj_ver]" - for
+           example, "MyFirstWorkspace/MyFirstObject/3" would identify the
+           third version of an object called MyFirstObject in the workspace
+           called MyFirstWorkspace. 42/Panic/1 would identify the first
+           version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
+           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
+           version of an object with id 567 in a workspace with id 23. In all
+           cases, if the version number is omitted, the latest version of the
+           object is assumed.), parameter "resolved_ws_objects" of list of
+           type "obj_ref" (A string that uniquely identifies an object in the
+           workspace service. There are two ways to uniquely identify an
+           object in one string: "[ws_name or id]/[obj_name or id]/[obj_ver]"
+           - for example, "MyFirstWorkspace/MyFirstObject/3" would identify
+           the third version of an object called MyFirstObject in the
+           workspace called MyFirstWorkspace. 42/Panic/1 would identify the
+           first version of the object name Panic in workspace with id 42.
+           Towel/1/6 would identify the 6th version of the object with id 1
+           in the Towel workspace. "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]"
+           - for example, "kb|ws.23.obj.567.ver.2" would identify the second
+           version of an object with id 567 in a workspace with id 23. In all
+           cases, if the version number is omitted, the latest version of the
+           object is assumed.), parameter "intermediate_incoming" of list of
+           String, parameter "intermediate_outgoing" of list of String,
+           parameter "external_data" of list of type "ExternalDataUnit" (An
+           external data unit. A piece of data from a source outside the
+           Workspace. On input, only one of the resource_release_date or
+           resource_release_epoch may be supplied. Both are supplied on
+           output. string resource_name - the name of the resource, for
+           example JGI. string resource_url - the url of the resource, for
+           example http://genome.jgi.doe.gov string resource_version -
+           version of the resource timestamp resource_release_date - the
+           release date of the resource epoch resource_release_epoch - the
+           release date of the resource string data_url - the url of the
+           data, for example
+           http://genome.jgi.doe.gov/pages/dynamicOrganismDownload.jsf?
+           organism=BlaspURHD0036 string data_id - the id of the data, for
+           example 7625.2.79179.AGTTCC.adnq.fastq.gz string description - a
+           free text description of the data.) -> structure: parameter
+           "resource_name" of String, parameter "resource_url" of String,
+           parameter "resource_version" of String, parameter
+           "resource_release_date" of type "timestamp" (A time in the format
+           YYYY-MM-DDThh:mm:ssZ, where Z is either the character Z
+           (representing the UTC timezone) or the difference in time to UTC
+           in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500 (EST time)
+           2013-04-03T08:56:32+0000 (UTC time) 2013-04-03T08:56:32Z (UTC
+           time)), parameter "resource_release_epoch" of type "epoch" (A Unix
+           epoch (the time since 00:00:00 1/1/1970 UTC) in milliseconds.),
+           parameter "data_url" of String, parameter "data_id" of String,
+           parameter "description" of String, parameter "subactions" of list
+           of type "SubAction" (Information about a subaction that is invoked
+           by a provenance action. A provenance action (PA) may invoke
+           subactions (SA), e.g. calling a separate piece of code, a service,
+           or a script. In most cases these calls are the same from PA to PA
+           and so do not need to be listed in the provenance since providing
+           information about the PA alone provides reproducibility. In some
+           cases, however, SAs may change over time, such that invoking the
+           same PA with the same parameters may produce different results.
+           For example, if a PA calls a remote server, that server may be
+           updated between a PA invoked on day T and another PA invoked on
+           day T+1. The SubAction structure allows for specifying information
+           about SAs that may dynamically change from PA invocation to PA
+           invocation. string name - the name of the SA. string ver - the
+           version of SA. string code_url - a url pointing to the SA's
+           codebase. string commit - a version control commit ID for the SA.
+           string endpoint_url - a url pointing to the access point for the
+           SA - a server url, for instance.) -> structure: parameter "name"
+           of String, parameter "ver" of String, parameter "code_url" of
+           String, parameter "commit" of String, parameter "endpoint_url" of
+           String, parameter "custom" of mapping from String to String,
+           parameter "description" of String
+        :returns: instance of type "SaveLegacyGenomeResult" -> structure:
+           parameter "info" of list of type "object_info" (Information about
+           an object, including user provided metadata. obj_id objid - the
+           numerical id of the object. obj_name name - the name of the
+           object. type_string type - the type of the object. timestamp
+           save_date - the save date of the object. obj_ver ver - the version
+           of the object. username saved_by - the user that saved or copied
+           the object. ws_id wsid - the workspace containing the object.
+           ws_name workspace - the workspace containing the object. string
+           chsum - the md5 checksum of the object. int size - the size of the
+           object in bytes. usermeta meta - arbitrary user-supplied metadata
+           about the object.) -> tuple of size 11: parameter "objid" of type
+           "obj_id" (The unique, permanent numerical ID of an object.),
+           parameter "name" of type "obj_name" (A string used as a name for
+           an object. Any string consisting of alphanumeric characters and
+           the characters |._- that is not an integer is acceptable.),
+           parameter "type" of type "type_string" (A type string. Specifies
+           the type and its version in a single string in the format
+           [module].[typename]-[major].[minor]: module - a string. The module
+           name of the typespec containing the type. typename - a string. The
+           name of the type as assigned by the typedef statement. major - an
+           integer. The major version of the type. A change in the major
+           version implies the type has changed in a non-backwards compatible
+           way. minor - an integer. The minor version of the type. A change
+           in the minor version implies that the type has changed in a way
+           that is backwards compatible with previous type definitions. In
+           many cases, the major and minor versions are optional, and if not
+           provided the most recent version will be used. Example:
+           MyModule.MyType-3.1), parameter "save_date" of type "timestamp" (A
+           time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+           character Z (representing the UTC timezone) or the difference in
+           time to UTC in the format +/-HHMM, eg: 2012-12-17T23:24:06-0500
+           (EST time) 2013-04-03T08:56:32+0000 (UTC time)
+           2013-04-03T08:56:32Z (UTC time)), parameter "version" of Long,
+           parameter "saved_by" of type "username" (Login name of a KBase
+           user account.), parameter "wsid" of type "ws_id" (The unique,
+           permanent numerical ID of a workspace.), parameter "workspace" of
+           type "ws_name" (A string used as a name for a workspace. Any
+           string consisting of alphanumeric characters and "_", ".", or "-"
+           that is not an integer is acceptable. The name may optionally be
+           prefixed with the workspace owner's user name and a colon, e.g.
+           kbasetest:my_workspace.), parameter "chsum" of String, parameter
+           "size" of Long, parameter "meta" of type "usermeta" (User provided
+           metadata about an object. Arbitrary key-value pairs provided by
+           the user.) -> mapping from String to String
+        """
+        # ctx is the context object
+        # return variables are: result
+        #BEGIN save_one_legacy_genome
+        #END save_one_legacy_genome
+
+        # At some point might do deeper type checking...
+        if not isinstance(result, dict):
+            raise ValueError('Method save_one_legacy_genome return value ' +
+                             'result is not type dict as required.')
+        # return the results
+        return [result]
 
     def status(self, ctx):
         #BEGIN_STATUS

--- a/lib/GenomeAnnotationAPI/GenomeAnnotationAPIServer.py
+++ b/lib/GenomeAnnotationAPI/GenomeAnnotationAPIServer.py
@@ -429,6 +429,14 @@ class Application(object):
                              name='GenomeAnnotationAPI.get_combined_data',
                              types=[dict])
         self.method_authentication['GenomeAnnotationAPI.get_combined_data'] = 'required'
+        self.rpc_service.add(impl_GenomeAnnotationAPI.get_legacy_genome,
+                             name='GenomeAnnotationAPI.get_legacy_genome',
+                             types=[dict])
+        self.method_authentication['GenomeAnnotationAPI.get_legacy_genome'] = 'required'
+        self.rpc_service.add(impl_GenomeAnnotationAPI.save_one_legacy_genome,
+                             name='GenomeAnnotationAPI.save_one_legacy_genome',
+                             types=[dict])
+        self.method_authentication['GenomeAnnotationAPI.save_one_legacy_genome'] = 'required'
         self.rpc_service.add(impl_GenomeAnnotationAPI.status,
                              name='GenomeAnnotationAPI.status',
                              types=[dict])

--- a/lib/GenomeAnnotationAPI/GenomeAnnotationAPIServer.py
+++ b/lib/GenomeAnnotationAPI/GenomeAnnotationAPIServer.py
@@ -432,11 +432,11 @@ class Application(object):
         self.rpc_service.add(impl_GenomeAnnotationAPI.get_legacy_genome,
                              name='GenomeAnnotationAPI.get_legacy_genome',
                              types=[dict])
-        self.method_authentication['GenomeAnnotationAPI.get_legacy_genome'] = 'required'
+        self.method_authentication['GenomeAnnotationAPI.get_legacy_genome'] = 'optional'
         self.rpc_service.add(impl_GenomeAnnotationAPI.save_one_legacy_genome,
                              name='GenomeAnnotationAPI.save_one_legacy_genome',
                              types=[dict])
-        self.method_authentication['GenomeAnnotationAPI.save_one_legacy_genome'] = 'required'
+        self.method_authentication['GenomeAnnotationAPI.save_one_legacy_genome'] = 'optional'
         self.rpc_service.add(impl_GenomeAnnotationAPI.status,
                              name='GenomeAnnotationAPI.status',
                              types=[dict])

--- a/lib/GenomeAnnotationAPI/LegacyGenomeInterface.py
+++ b/lib/GenomeAnnotationAPI/LegacyGenomeInterface.py
@@ -1,0 +1,168 @@
+
+
+from biokbase.workspace.client import Workspace
+
+
+from pprint import pprint
+
+class LegacyGenomeInterface:
+
+
+    def __init__(self, workspace_client):
+        self.ws = workspace_client;
+
+
+    # INPUT STRUCTURES:
+    # typedef structure {
+    #     string ref;
+    #     list <int> included_feature_position_index;
+    #     list <string> ref_path_to_genome;
+    # } LegacyGenomeSelector;
+
+    # typedef structure {
+    #     list <LegacyGenomeSelector> genomes;
+    #     list <string> included_fields;
+    #     list <string> included_feature_fields;
+    #     boolean ignore_errors;
+    #     boolean no_data;
+    #     boolean no_metadata;
+    # } GetLegacyGenomeParams;
+
+    def get_legacy_genome(self, ctx, params):
+
+        object_specifications = self.build_object_specifications(params)
+
+        getObjParams = { 'objects':object_specifications }
+
+        if 'ignoreErrors' in params:
+            if params['ignoreErrors']==0:
+                getObjParams['ignoreErrors']=0
+            elif params['ignoreErrors']==1:
+                getObjParams['ignoreErrors']=1
+            else:
+                raise ValueError('ignoreErrors input field must be set to 0 or 1')
+
+        if 'no_data' in params:
+            if params['no_data']==0:
+                getObjParams['no_data']=0
+            elif params['no_data']==1:
+                getObjParams['no_data']=1
+            else:
+                raise ValueError('no_data input field must be set to 0 or 1')
+
+        data = self.ws.get_objects2(getObjParams)['data']
+
+        if 'no_metadata' in params:
+            if params['no_metadata']==1:
+                d2 = []
+                for obj in data:
+                    d2.append({'data':obj['data']})
+                data = d2
+
+        returnPackage = { 'genomes':data }
+        return returnPackage
+
+
+    def build_object_specifications(self,params):
+
+        if 'genomes' not in params:
+            raise ValueError('Invalid input - "genomes" input argument field is missing.')
+        genomes = params['genomes']
+
+        included_fields = []
+        if 'included_fields' in params:
+            included_fields = params['included_fields']
+
+        included_feature_fields = []
+        if 'included_feature_fields' in params:
+            included_feature_fields = params['included_feature_fields']
+
+        # typedef structure {
+        #     ws_name workspace;
+        #     ws_id wsid;
+        #     obj_name name;
+        #     obj_id objid;
+        #     obj_ver ver;
+        #     obj_ref ref;
+        #     ref_chain obj_path;
+        #     list<obj_ref> obj_ref_path;
+        #     list<object_path> included;
+        #     boolean strict_maps;
+        #     boolean strict_arrays;
+        # } ObjectSpecification;
+
+        object_specifications = []
+        for g in genomes:
+            # create the WS object selector, include the basic fields specified
+            ref_path_to_genome = []
+            if 'ref_path_to_genome' in g:
+                ref_path_to_genome = g['ref_path_to_genome']
+            selector = self.create_base_object_spec(g['ref'],ref_path_to_genome)
+            included = included_fields
+
+            # if there are specific features selected, get those
+            if 'included_feature_position_index' in g and len(g['included_feature_position_index'])>0:
+                for pos in g['included_feature_position_index']:
+                    base = 'features/'+str(pos)
+                    included_feature_paths = self.create_feature_selectors(base, included_feature_fields)
+                    for p in included_feature_paths:
+                        included.append(p)
+            # no selected features, but if included_feature_fields is defined, do that
+            elif len(included_feature_fields) >0:
+                included_feature_paths = self.create_feature_selectors('features/[*]', included_feature_fields)
+                for p in included_feature_paths:
+                    included.append(p)
+
+            selector['included'] = included
+
+            object_specifications.append(selector)
+        return object_specifications
+
+
+    def create_feature_selectors(self, base, included_feature_fields):
+        included = []
+        if len(included_feature_fields)>0:
+            for f in included_feature_fields:
+                included.append( base + '/' + f)
+        else:
+            included = [base]
+        return included
+      
+    # Possible todo: make sure everything is the right type
+    #def check_type_is_genome(genomes):
+    #    pass
+
+
+
+    def create_base_object_spec(self, genome_ref, ref_path_to_genome):
+        if ref_path_to_genome is not None:
+            if len(ref_path_to_genome)>0:
+                obj_ref_path = []
+                for r in ref_path_to_genome[1:]:
+                    obj_ref_path.append(r)
+                obj_ref_path.append(genome_ref)
+
+                return {
+                    'ref': ref_path_to_genome[0],
+                    'obj_ref_path':obj_ref_path
+                }
+        return { 'ref':genome_ref }
+
+
+
+
+    def save_one_legacy_genome(self, ctx, params):
+
+
+
+
+
+        
+        return {}
+
+
+
+
+
+
+

--- a/lib/GenomeAnnotationAPI/authclient.py
+++ b/lib/GenomeAnnotationAPI/authclient.py
@@ -8,7 +8,6 @@ A very basic KBase auth client for the Python server.
 import time as _time
 import requests as _requests
 import threading as _threading
-import hashlib
 
 
 class TokenCache(object):
@@ -24,7 +23,6 @@ class TokenCache(object):
         self._halfmax = maxsize / 2  # int division to round down
 
     def get_user(self, token):
-        token = hashlib.sha256(token).hexdigest();
         with self._lock:
             usertime = self._cache.get(token)
         if not usertime:
@@ -37,10 +35,9 @@ class TokenCache(object):
 
     def add_valid_token(self, token, user):
         if not token:
-            raise ValueError('Must supply token')
+            raise ValueError('token cannot be None')
         if not user:
-            raise ValueError('Must supply user')
-        token = hashlib.sha256(token).hexdigest();
+            raise ValueError('user cannot be None')
         with self._lock:
             self._cache[token] = [user, _time.time()]
             if len(self._cache) > self._maxsize:
@@ -70,7 +67,7 @@ class KBaseAuth(object):
 
     def get_user(self, token):
         if not token:
-            raise ValueError('Must supply token')
+            raise ValueError('token cannot be None')
         user = self._cache.get_user(token)
         if user:
             return user

--- a/lib/javascript/Client.js
+++ b/lib/javascript/Client.js
@@ -343,6 +343,32 @@ function GenomeAnnotationAPI(url, auth, auth_cb, timeout, async_job_check_time_m
         return json_call_ajax(_url, "GenomeAnnotationAPI.get_combined_data",
             [params], 1, _callback, _errorCallback);
     };
+ 
+     this.get_legacy_genome = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax(_url, "GenomeAnnotationAPI.get_legacy_genome",
+            [params], 1, _callback, _errorCallback);
+    };
+ 
+     this.save_one_legacy_genome = function (params, _callback, _errorCallback) {
+        if (typeof params === 'function')
+            throw 'Argument params can not be a function';
+        if (_callback && typeof _callback !== 'function')
+            throw 'Argument _callback must be a function if defined';
+        if (_errorCallback && typeof _errorCallback !== 'function')
+            throw 'Argument _errorCallback must be a function if defined';
+        if (typeof arguments === 'function' && arguments.length > 1+2)
+            throw 'Too many arguments ('+arguments.length+' instead of '+(1+2)+')';
+        return json_call_ajax(_url, "GenomeAnnotationAPI.save_one_legacy_genome",
+            [params], 1, _callback, _errorCallback);
+    };
   
     this.status = function (_callback, _errorCallback) {
         if (_callback && typeof _callback !== 'function')

--- a/lib/src/us/kbase/common/service/Tuple11.java
+++ b/lib/src/us/kbase/common/service/Tuple11.java
@@ -1,0 +1,179 @@
+package us.kbase.common.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+public class Tuple11 <T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> {
+    private T1 e1;
+    private T2 e2;
+    private T3 e3;
+    private T4 e4;
+    private T5 e5;
+    private T6 e6;
+    private T7 e7;
+    private T8 e8;
+    private T9 e9;
+    private T10 e10;
+    private T11 e11;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    public T1 getE1() {
+        return e1;
+    }
+
+    public void setE1(T1 e1) {
+        this.e1 = e1;
+    }
+
+    public Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> withE1(T1 e1) {
+        this.e1 = e1;
+        return this;
+    }
+
+    public T2 getE2() {
+        return e2;
+    }
+
+    public void setE2(T2 e2) {
+        this.e2 = e2;
+    }
+
+    public Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> withE2(T2 e2) {
+        this.e2 = e2;
+        return this;
+    }
+
+    public T3 getE3() {
+        return e3;
+    }
+
+    public void setE3(T3 e3) {
+        this.e3 = e3;
+    }
+
+    public Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> withE3(T3 e3) {
+        this.e3 = e3;
+        return this;
+    }
+
+    public T4 getE4() {
+        return e4;
+    }
+
+    public void setE4(T4 e4) {
+        this.e4 = e4;
+    }
+
+    public Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> withE4(T4 e4) {
+        this.e4 = e4;
+        return this;
+    }
+
+    public T5 getE5() {
+        return e5;
+    }
+
+    public void setE5(T5 e5) {
+        this.e5 = e5;
+    }
+
+    public Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> withE5(T5 e5) {
+        this.e5 = e5;
+        return this;
+    }
+
+    public T6 getE6() {
+        return e6;
+    }
+
+    public void setE6(T6 e6) {
+        this.e6 = e6;
+    }
+
+    public Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> withE6(T6 e6) {
+        this.e6 = e6;
+        return this;
+    }
+
+    public T7 getE7() {
+        return e7;
+    }
+
+    public void setE7(T7 e7) {
+        this.e7 = e7;
+    }
+
+    public Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> withE7(T7 e7) {
+        this.e7 = e7;
+        return this;
+    }
+
+    public T8 getE8() {
+        return e8;
+    }
+
+    public void setE8(T8 e8) {
+        this.e8 = e8;
+    }
+
+    public Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> withE8(T8 e8) {
+        this.e8 = e8;
+        return this;
+    }
+
+    public T9 getE9() {
+        return e9;
+    }
+
+    public void setE9(T9 e9) {
+        this.e9 = e9;
+    }
+
+    public Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> withE9(T9 e9) {
+        this.e9 = e9;
+        return this;
+    }
+
+    public T10 getE10() {
+        return e10;
+    }
+
+    public void setE10(T10 e10) {
+        this.e10 = e10;
+    }
+
+    public Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> withE10(T10 e10) {
+        this.e10 = e10;
+        return this;
+    }
+
+    public T11 getE11() {
+        return e11;
+    }
+
+    public void setE11(T11 e11) {
+        this.e11 = e11;
+    }
+
+    public Tuple11<T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11> withE11(T11 e11) {
+        this.e11 = e11;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "Tuple11 [e1=" + e1 + ", e2=" + e2 + ", e3=" + e3 + ", e4=" + e4 + ", e5=" + e5 + ", e6=" + e6 + ", e7=" + e7 + ", e8=" + e8 + ", e9=" + e9 + ", e10=" + e10 + ", e11=" + e11 + "]";
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/lib/src/us/kbase/common/service/Tuple3.java
+++ b/lib/src/us/kbase/common/service/Tuple3.java
@@ -1,0 +1,67 @@
+package us.kbase.common.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+public class Tuple3 <T1, T2, T3> {
+    private T1 e1;
+    private T2 e2;
+    private T3 e3;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    public T1 getE1() {
+        return e1;
+    }
+
+    public void setE1(T1 e1) {
+        this.e1 = e1;
+    }
+
+    public Tuple3<T1, T2, T3> withE1(T1 e1) {
+        this.e1 = e1;
+        return this;
+    }
+
+    public T2 getE2() {
+        return e2;
+    }
+
+    public void setE2(T2 e2) {
+        this.e2 = e2;
+    }
+
+    public Tuple3<T1, T2, T3> withE2(T2 e2) {
+        this.e2 = e2;
+        return this;
+    }
+
+    public T3 getE3() {
+        return e3;
+    }
+
+    public void setE3(T3 e3) {
+        this.e3 = e3;
+    }
+
+    public Tuple3<T1, T2, T3> withE3(T3 e3) {
+        this.e3 = e3;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "Tuple3 [e1=" + e1 + ", e2=" + e2 + ", e3=" + e3 + "]";
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/lib/src/us/kbase/common/service/Tuple4.java
+++ b/lib/src/us/kbase/common/service/Tuple4.java
@@ -1,0 +1,81 @@
+package us.kbase.common.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+public class Tuple4 <T1, T2, T3, T4> {
+    private T1 e1;
+    private T2 e2;
+    private T3 e3;
+    private T4 e4;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    public T1 getE1() {
+        return e1;
+    }
+
+    public void setE1(T1 e1) {
+        this.e1 = e1;
+    }
+
+    public Tuple4<T1, T2, T3, T4> withE1(T1 e1) {
+        this.e1 = e1;
+        return this;
+    }
+
+    public T2 getE2() {
+        return e2;
+    }
+
+    public void setE2(T2 e2) {
+        this.e2 = e2;
+    }
+
+    public Tuple4<T1, T2, T3, T4> withE2(T2 e2) {
+        this.e2 = e2;
+        return this;
+    }
+
+    public T3 getE3() {
+        return e3;
+    }
+
+    public void setE3(T3 e3) {
+        this.e3 = e3;
+    }
+
+    public Tuple4<T1, T2, T3, T4> withE3(T3 e3) {
+        this.e3 = e3;
+        return this;
+    }
+
+    public T4 getE4() {
+        return e4;
+    }
+
+    public void setE4(T4 e4) {
+        this.e4 = e4;
+    }
+
+    public Tuple4<T1, T2, T3, T4> withE4(T4 e4) {
+        this.e4 = e4;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "Tuple4 [e1=" + e1 + ", e2=" + e2 + ", e3=" + e3 + ", e4=" + e4 + "]";
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/lib/src/us/kbase/common/service/Tuple7.java
+++ b/lib/src/us/kbase/common/service/Tuple7.java
@@ -1,0 +1,123 @@
+package us.kbase.common.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+
+public class Tuple7 <T1, T2, T3, T4, T5, T6, T7> {
+    private T1 e1;
+    private T2 e2;
+    private T3 e3;
+    private T4 e4;
+    private T5 e5;
+    private T6 e6;
+    private T7 e7;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    public T1 getE1() {
+        return e1;
+    }
+
+    public void setE1(T1 e1) {
+        this.e1 = e1;
+    }
+
+    public Tuple7<T1, T2, T3, T4, T5, T6, T7> withE1(T1 e1) {
+        this.e1 = e1;
+        return this;
+    }
+
+    public T2 getE2() {
+        return e2;
+    }
+
+    public void setE2(T2 e2) {
+        this.e2 = e2;
+    }
+
+    public Tuple7<T1, T2, T3, T4, T5, T6, T7> withE2(T2 e2) {
+        this.e2 = e2;
+        return this;
+    }
+
+    public T3 getE3() {
+        return e3;
+    }
+
+    public void setE3(T3 e3) {
+        this.e3 = e3;
+    }
+
+    public Tuple7<T1, T2, T3, T4, T5, T6, T7> withE3(T3 e3) {
+        this.e3 = e3;
+        return this;
+    }
+
+    public T4 getE4() {
+        return e4;
+    }
+
+    public void setE4(T4 e4) {
+        this.e4 = e4;
+    }
+
+    public Tuple7<T1, T2, T3, T4, T5, T6, T7> withE4(T4 e4) {
+        this.e4 = e4;
+        return this;
+    }
+
+    public T5 getE5() {
+        return e5;
+    }
+
+    public void setE5(T5 e5) {
+        this.e5 = e5;
+    }
+
+    public Tuple7<T1, T2, T3, T4, T5, T6, T7> withE5(T5 e5) {
+        this.e5 = e5;
+        return this;
+    }
+
+    public T6 getE6() {
+        return e6;
+    }
+
+    public void setE6(T6 e6) {
+        this.e6 = e6;
+    }
+
+    public Tuple7<T1, T2, T3, T4, T5, T6, T7> withE6(T6 e6) {
+        this.e6 = e6;
+        return this;
+    }
+
+    public T7 getE7() {
+        return e7;
+    }
+
+    public void setE7(T7 e7) {
+        this.e7 = e7;
+    }
+
+    public Tuple7<T1, T2, T3, T4, T5, T6, T7> withE7(T7 e7) {
+        this.e7 = e7;
+        return this;
+    }
+
+    @Override
+    public String toString() {
+        return "Tuple7 [e1=" + e1 + ", e2=" + e2 + ", e3=" + e3 + ", e4=" + e4 + ", e5=" + e5 + ", e6=" + e6 + ", e7=" + e7 + "]";
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+}

--- a/lib/src/us/kbase/genomeannotationapi/GenomeAnnotationAPIClient.java
+++ b/lib/src/us/kbase/genomeannotationapi/GenomeAnnotationAPIClient.java
@@ -17,7 +17,6 @@ import us.kbase.common.service.UnauthorizedException;
 /**
  * <p>Original spec-file module name: GenomeAnnotationAPI</p>
  * <pre>
- * A KBase module: GenomeAnnotationAPI
  * </pre>
  */
 public class GenomeAnnotationAPIClient {
@@ -593,6 +592,40 @@ public class GenomeAnnotationAPIClient {
         args.add(params);
         TypeReference<List<GenomeAnnotationData>> retType = new TypeReference<List<GenomeAnnotationData>>() {};
         List<GenomeAnnotationData> res = caller.jsonrpcCall("GenomeAnnotationAPI.get_combined_data", args, retType, true, true, jsonRpcContext, this.serviceVersion);
+        return res.get(0);
+    }
+
+    /**
+     * <p>Original spec-file function name: get_legacy_genome</p>
+     * <pre>
+     * </pre>
+     * @param   params   instance of type {@link us.kbase.genomeannotationapi.GetLegacyGenomeParams GetLegacyGenomeParams}
+     * @return   parameter "data" of type {@link us.kbase.genomeannotationapi.LegacyGenomeData LegacyGenomeData}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public LegacyGenomeData getLegacyGenome(GetLegacyGenomeParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<List<LegacyGenomeData>> retType = new TypeReference<List<LegacyGenomeData>>() {};
+        List<LegacyGenomeData> res = caller.jsonrpcCall("GenomeAnnotationAPI.get_legacy_genome", args, retType, true, true, jsonRpcContext, this.serviceVersion);
+        return res.get(0);
+    }
+
+    /**
+     * <p>Original spec-file function name: save_one_legacy_genome</p>
+     * <pre>
+     * </pre>
+     * @param   params   instance of type {@link us.kbase.genomeannotationapi.SaveLegacyGenomeParams SaveLegacyGenomeParams}
+     * @return   parameter "result" of type {@link us.kbase.genomeannotationapi.SaveLegacyGenomeResult SaveLegacyGenomeResult}
+     * @throws IOException if an IO exception occurs
+     * @throws JsonClientException if a JSON RPC exception occurs
+     */
+    public SaveLegacyGenomeResult saveOneLegacyGenome(SaveLegacyGenomeParams params, RpcContext... jsonRpcContext) throws IOException, JsonClientException {
+        List<Object> args = new ArrayList<Object>();
+        args.add(params);
+        TypeReference<List<SaveLegacyGenomeResult>> retType = new TypeReference<List<SaveLegacyGenomeResult>>() {};
+        List<SaveLegacyGenomeResult> res = caller.jsonrpcCall("GenomeAnnotationAPI.save_one_legacy_genome", args, retType, true, true, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 

--- a/lib/src/us/kbase/genomeannotationapi/GenomeAnnotationAPIClient.java
+++ b/lib/src/us/kbase/genomeannotationapi/GenomeAnnotationAPIClient.java
@@ -608,7 +608,7 @@ public class GenomeAnnotationAPIClient {
         List<Object> args = new ArrayList<Object>();
         args.add(params);
         TypeReference<List<LegacyGenomeData>> retType = new TypeReference<List<LegacyGenomeData>>() {};
-        List<LegacyGenomeData> res = caller.jsonrpcCall("GenomeAnnotationAPI.get_legacy_genome", args, retType, true, true, jsonRpcContext, this.serviceVersion);
+        List<LegacyGenomeData> res = caller.jsonrpcCall("GenomeAnnotationAPI.get_legacy_genome", args, retType, true, false, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 
@@ -625,7 +625,7 @@ public class GenomeAnnotationAPIClient {
         List<Object> args = new ArrayList<Object>();
         args.add(params);
         TypeReference<List<SaveLegacyGenomeResult>> retType = new TypeReference<List<SaveLegacyGenomeResult>>() {};
-        List<SaveLegacyGenomeResult> res = caller.jsonrpcCall("GenomeAnnotationAPI.save_one_legacy_genome", args, retType, true, true, jsonRpcContext, this.serviceVersion);
+        List<SaveLegacyGenomeResult> res = caller.jsonrpcCall("GenomeAnnotationAPI.save_one_legacy_genome", args, retType, true, false, jsonRpcContext, this.serviceVersion);
         return res.get(0);
     }
 

--- a/lib/src/us/kbase/genomeannotationapi/GetLegacyGenomeParams.java
+++ b/lib/src/us/kbase/genomeannotationapi/GetLegacyGenomeParams.java
@@ -21,6 +21,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @Generated("com.googlecode.jsonschema2pojo")
 @JsonPropertyOrder({
     "genomes",
+    "included_fields",
+    "included_feature_fields",
     "ignore_errors",
     "no_data"
 })
@@ -28,11 +30,15 @@ public class GetLegacyGenomeParams {
 
     @JsonProperty("genomes")
     private List<LegacyGenomeSelector> genomes;
+    @JsonProperty("included_fields")
+    private List<String> includedFields;
+    @JsonProperty("included_feature_fields")
+    private List<String> includedFeatureFields;
     @JsonProperty("ignore_errors")
     private Long ignoreErrors;
     @JsonProperty("no_data")
     private Long noData;
-    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
 
     @JsonProperty("genomes")
     public List<LegacyGenomeSelector> getGenomes() {
@@ -46,6 +52,36 @@ public class GetLegacyGenomeParams {
 
     public GetLegacyGenomeParams withGenomes(List<LegacyGenomeSelector> genomes) {
         this.genomes = genomes;
+        return this;
+    }
+
+    @JsonProperty("included_fields")
+    public List<String> getIncludedFields() {
+        return includedFields;
+    }
+
+    @JsonProperty("included_fields")
+    public void setIncludedFields(List<String> includedFields) {
+        this.includedFields = includedFields;
+    }
+
+    public GetLegacyGenomeParams withIncludedFields(List<String> includedFields) {
+        this.includedFields = includedFields;
+        return this;
+    }
+
+    @JsonProperty("included_feature_fields")
+    public List<String> getIncludedFeatureFields() {
+        return includedFeatureFields;
+    }
+
+    @JsonProperty("included_feature_fields")
+    public void setIncludedFeatureFields(List<String> includedFeatureFields) {
+        this.includedFeatureFields = includedFeatureFields;
+    }
+
+    public GetLegacyGenomeParams withIncludedFeatureFields(List<String> includedFeatureFields) {
+        this.includedFeatureFields = includedFeatureFields;
         return this;
     }
 
@@ -80,18 +116,18 @@ public class GetLegacyGenomeParams {
     }
 
     @JsonAnyGetter
-    public Map<String, Object> getAdditionalProperties() {
+    public Map<java.lang.String, Object> getAdditionalProperties() {
         return this.additionalProperties;
     }
 
     @JsonAnySetter
-    public void setAdditionalProperties(String name, Object value) {
+    public void setAdditionalProperties(java.lang.String name, Object value) {
         this.additionalProperties.put(name, value);
     }
 
     @Override
-    public String toString() {
-        return ((((((((("GetLegacyGenomeParams"+" [genomes=")+ genomes)+", ignoreErrors=")+ ignoreErrors)+", noData=")+ noData)+", additionalProperties=")+ additionalProperties)+"]");
+    public java.lang.String toString() {
+        return ((((((((((((("GetLegacyGenomeParams"+" [genomes=")+ genomes)+", includedFields=")+ includedFields)+", includedFeatureFields=")+ includedFeatureFields)+", ignoreErrors=")+ ignoreErrors)+", noData=")+ noData)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/src/us/kbase/genomeannotationapi/GetLegacyGenomeParams.java
+++ b/lib/src/us/kbase/genomeannotationapi/GetLegacyGenomeParams.java
@@ -1,0 +1,97 @@
+
+package us.kbase.genomeannotationapi;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: GetLegacyGenomeParams</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "genomes",
+    "ignore_errors",
+    "no_data"
+})
+public class GetLegacyGenomeParams {
+
+    @JsonProperty("genomes")
+    private List<LegacyGenomeSelector> genomes;
+    @JsonProperty("ignore_errors")
+    private Long ignoreErrors;
+    @JsonProperty("no_data")
+    private Long noData;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("genomes")
+    public List<LegacyGenomeSelector> getGenomes() {
+        return genomes;
+    }
+
+    @JsonProperty("genomes")
+    public void setGenomes(List<LegacyGenomeSelector> genomes) {
+        this.genomes = genomes;
+    }
+
+    public GetLegacyGenomeParams withGenomes(List<LegacyGenomeSelector> genomes) {
+        this.genomes = genomes;
+        return this;
+    }
+
+    @JsonProperty("ignore_errors")
+    public Long getIgnoreErrors() {
+        return ignoreErrors;
+    }
+
+    @JsonProperty("ignore_errors")
+    public void setIgnoreErrors(Long ignoreErrors) {
+        this.ignoreErrors = ignoreErrors;
+    }
+
+    public GetLegacyGenomeParams withIgnoreErrors(Long ignoreErrors) {
+        this.ignoreErrors = ignoreErrors;
+        return this;
+    }
+
+    @JsonProperty("no_data")
+    public Long getNoData() {
+        return noData;
+    }
+
+    @JsonProperty("no_data")
+    public void setNoData(Long noData) {
+        this.noData = noData;
+    }
+
+    public GetLegacyGenomeParams withNoData(Long noData) {
+        this.noData = noData;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((("GetLegacyGenomeParams"+" [genomes=")+ genomes)+", ignoreErrors=")+ ignoreErrors)+", noData=")+ noData)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/genomeannotationapi/LegacyGenomeData.java
+++ b/lib/src/us/kbase/genomeannotationapi/LegacyGenomeData.java
@@ -1,0 +1,324 @@
+
+package us.kbase.genomeannotationapi;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import us.kbase.common.service.Tuple11;
+import us.kbase.kbasegenomes.Genome;
+import us.kbase.workspace.ProvenanceAction;
+
+
+/**
+ * <p>Original spec-file type: LegacyGenomeData</p>
+ * <pre>
+ * todo: import Genome type and use it here
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "data",
+    "info",
+    "provenance",
+    "creator",
+    "orig_wsid",
+    "copied",
+    "copy_source_inaccessible",
+    "created",
+    "epoch",
+    "handle_error",
+    "handle_stacktrace"
+})
+public class LegacyGenomeData {
+
+    /**
+     * <p>Original spec-file type: Genome</p>
+     * <pre>
+     * Genome object holds much of the data relevant for a genome in KBase
+     *         Genome publications should be papers about the genome, not
+     *         papers about certain features of the genome (which go into the
+     *         Feature object)
+     *         Should the Genome object have a list of feature ids? (in
+     *         addition to having a list of feature_refs)
+     *         Should the Genome object contain a list of contig_ids too?
+     * @optional assembly_ref quality close_genomes analysis_events features source_id source contigs contig_ids publications md5 taxonomy gc_content complete dna_size num_contigs contig_lengths contigset_ref
+     * @metadata ws gc_content as GC content
+     * @metadata ws taxonomy as Taxonomy
+     * @metadata ws md5 as MD5
+     * @metadata ws dna_size as Size
+     * @metadata ws genetic_code as Genetic code
+     * @metadata ws domain as Domain
+     *     @metadata ws source_id as Source ID
+     *     @metadata ws source as Source
+     *     @metadata ws scientific_name as Name
+     *     @metadata ws length(close_genomes) as Close genomes
+     *     @metadata ws length(features) as Number features
+     *     @metadata ws num_contigs as Number contigs
+     * </pre>
+     * 
+     */
+    @JsonProperty("data")
+    private Genome data;
+    @JsonProperty("info")
+    private Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info;
+    @JsonProperty("provenance")
+    private List<ProvenanceAction> provenance;
+    @JsonProperty("creator")
+    private java.lang.String creator;
+    @JsonProperty("orig_wsid")
+    private java.lang.String origWsid;
+    @JsonProperty("copied")
+    private java.lang.String copied;
+    @JsonProperty("copy_source_inaccessible")
+    private java.lang.Long copySourceInaccessible;
+    @JsonProperty("created")
+    private java.lang.String created;
+    @JsonProperty("epoch")
+    private java.lang.Long epoch;
+    @JsonProperty("handle_error")
+    private java.lang.String handleError;
+    @JsonProperty("handle_stacktrace")
+    private java.lang.String handleStacktrace;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    /**
+     * <p>Original spec-file type: Genome</p>
+     * <pre>
+     * Genome object holds much of the data relevant for a genome in KBase
+     *         Genome publications should be papers about the genome, not
+     *         papers about certain features of the genome (which go into the
+     *         Feature object)
+     *         Should the Genome object have a list of feature ids? (in
+     *         addition to having a list of feature_refs)
+     *         Should the Genome object contain a list of contig_ids too?
+     * @optional assembly_ref quality close_genomes analysis_events features source_id source contigs contig_ids publications md5 taxonomy gc_content complete dna_size num_contigs contig_lengths contigset_ref
+     * @metadata ws gc_content as GC content
+     * @metadata ws taxonomy as Taxonomy
+     * @metadata ws md5 as MD5
+     * @metadata ws dna_size as Size
+     * @metadata ws genetic_code as Genetic code
+     * @metadata ws domain as Domain
+     *     @metadata ws source_id as Source ID
+     *     @metadata ws source as Source
+     *     @metadata ws scientific_name as Name
+     *     @metadata ws length(close_genomes) as Close genomes
+     *     @metadata ws length(features) as Number features
+     *     @metadata ws num_contigs as Number contigs
+     * </pre>
+     * 
+     */
+    @JsonProperty("data")
+    public Genome getData() {
+        return data;
+    }
+
+    /**
+     * <p>Original spec-file type: Genome</p>
+     * <pre>
+     * Genome object holds much of the data relevant for a genome in KBase
+     *         Genome publications should be papers about the genome, not
+     *         papers about certain features of the genome (which go into the
+     *         Feature object)
+     *         Should the Genome object have a list of feature ids? (in
+     *         addition to having a list of feature_refs)
+     *         Should the Genome object contain a list of contig_ids too?
+     * @optional assembly_ref quality close_genomes analysis_events features source_id source contigs contig_ids publications md5 taxonomy gc_content complete dna_size num_contigs contig_lengths contigset_ref
+     * @metadata ws gc_content as GC content
+     * @metadata ws taxonomy as Taxonomy
+     * @metadata ws md5 as MD5
+     * @metadata ws dna_size as Size
+     * @metadata ws genetic_code as Genetic code
+     * @metadata ws domain as Domain
+     *     @metadata ws source_id as Source ID
+     *     @metadata ws source as Source
+     *     @metadata ws scientific_name as Name
+     *     @metadata ws length(close_genomes) as Close genomes
+     *     @metadata ws length(features) as Number features
+     *     @metadata ws num_contigs as Number contigs
+     * </pre>
+     * 
+     */
+    @JsonProperty("data")
+    public void setData(Genome data) {
+        this.data = data;
+    }
+
+    public LegacyGenomeData withData(Genome data) {
+        this.data = data;
+        return this;
+    }
+
+    @JsonProperty("info")
+    public Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> getInfo() {
+        return info;
+    }
+
+    @JsonProperty("info")
+    public void setInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info) {
+        this.info = info;
+    }
+
+    public LegacyGenomeData withInfo(Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>> info) {
+        this.info = info;
+        return this;
+    }
+
+    @JsonProperty("provenance")
+    public List<ProvenanceAction> getProvenance() {
+        return provenance;
+    }
+
+    @JsonProperty("provenance")
+    public void setProvenance(List<ProvenanceAction> provenance) {
+        this.provenance = provenance;
+    }
+
+    public LegacyGenomeData withProvenance(List<ProvenanceAction> provenance) {
+        this.provenance = provenance;
+        return this;
+    }
+
+    @JsonProperty("creator")
+    public java.lang.String getCreator() {
+        return creator;
+    }
+
+    @JsonProperty("creator")
+    public void setCreator(java.lang.String creator) {
+        this.creator = creator;
+    }
+
+    public LegacyGenomeData withCreator(java.lang.String creator) {
+        this.creator = creator;
+        return this;
+    }
+
+    @JsonProperty("orig_wsid")
+    public java.lang.String getOrigWsid() {
+        return origWsid;
+    }
+
+    @JsonProperty("orig_wsid")
+    public void setOrigWsid(java.lang.String origWsid) {
+        this.origWsid = origWsid;
+    }
+
+    public LegacyGenomeData withOrigWsid(java.lang.String origWsid) {
+        this.origWsid = origWsid;
+        return this;
+    }
+
+    @JsonProperty("copied")
+    public java.lang.String getCopied() {
+        return copied;
+    }
+
+    @JsonProperty("copied")
+    public void setCopied(java.lang.String copied) {
+        this.copied = copied;
+    }
+
+    public LegacyGenomeData withCopied(java.lang.String copied) {
+        this.copied = copied;
+        return this;
+    }
+
+    @JsonProperty("copy_source_inaccessible")
+    public java.lang.Long getCopySourceInaccessible() {
+        return copySourceInaccessible;
+    }
+
+    @JsonProperty("copy_source_inaccessible")
+    public void setCopySourceInaccessible(java.lang.Long copySourceInaccessible) {
+        this.copySourceInaccessible = copySourceInaccessible;
+    }
+
+    public LegacyGenomeData withCopySourceInaccessible(java.lang.Long copySourceInaccessible) {
+        this.copySourceInaccessible = copySourceInaccessible;
+        return this;
+    }
+
+    @JsonProperty("created")
+    public java.lang.String getCreated() {
+        return created;
+    }
+
+    @JsonProperty("created")
+    public void setCreated(java.lang.String created) {
+        this.created = created;
+    }
+
+    public LegacyGenomeData withCreated(java.lang.String created) {
+        this.created = created;
+        return this;
+    }
+
+    @JsonProperty("epoch")
+    public java.lang.Long getEpoch() {
+        return epoch;
+    }
+
+    @JsonProperty("epoch")
+    public void setEpoch(java.lang.Long epoch) {
+        this.epoch = epoch;
+    }
+
+    public LegacyGenomeData withEpoch(java.lang.Long epoch) {
+        this.epoch = epoch;
+        return this;
+    }
+
+    @JsonProperty("handle_error")
+    public java.lang.String getHandleError() {
+        return handleError;
+    }
+
+    @JsonProperty("handle_error")
+    public void setHandleError(java.lang.String handleError) {
+        this.handleError = handleError;
+    }
+
+    public LegacyGenomeData withHandleError(java.lang.String handleError) {
+        this.handleError = handleError;
+        return this;
+    }
+
+    @JsonProperty("handle_stacktrace")
+    public java.lang.String getHandleStacktrace() {
+        return handleStacktrace;
+    }
+
+    @JsonProperty("handle_stacktrace")
+    public void setHandleStacktrace(java.lang.String handleStacktrace) {
+        this.handleStacktrace = handleStacktrace;
+    }
+
+    public LegacyGenomeData withHandleStacktrace(java.lang.String handleStacktrace) {
+        this.handleStacktrace = handleStacktrace;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((((((((((((((((((((("LegacyGenomeData"+" [data=")+ data)+", info=")+ info)+", provenance=")+ provenance)+", creator=")+ creator)+", origWsid=")+ origWsid)+", copied=")+ copied)+", copySourceInaccessible=")+ copySourceInaccessible)+", created=")+ created)+", epoch=")+ epoch)+", handleError=")+ handleError)+", handleStacktrace=")+ handleStacktrace)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/genomeannotationapi/LegacyGenomeData.java
+++ b/lib/src/us/kbase/genomeannotationapi/LegacyGenomeData.java
@@ -34,6 +34,8 @@ import us.kbase.workspace.ProvenanceAction;
     "copy_source_inaccessible",
     "created",
     "epoch",
+    "refs",
+    "extracted_ids",
     "handle_error",
     "handle_stacktrace"
 })
@@ -83,6 +85,10 @@ public class LegacyGenomeData {
     private java.lang.String created;
     @JsonProperty("epoch")
     private java.lang.Long epoch;
+    @JsonProperty("refs")
+    private List<String> refs;
+    @JsonProperty("extracted_ids")
+    private Map<String, List<String>> extractedIds;
     @JsonProperty("handle_error")
     private java.lang.String handleError;
     @JsonProperty("handle_stacktrace")
@@ -276,6 +282,36 @@ public class LegacyGenomeData {
         return this;
     }
 
+    @JsonProperty("refs")
+    public List<String> getRefs() {
+        return refs;
+    }
+
+    @JsonProperty("refs")
+    public void setRefs(List<String> refs) {
+        this.refs = refs;
+    }
+
+    public LegacyGenomeData withRefs(List<String> refs) {
+        this.refs = refs;
+        return this;
+    }
+
+    @JsonProperty("extracted_ids")
+    public Map<String, List<String>> getExtractedIds() {
+        return extractedIds;
+    }
+
+    @JsonProperty("extracted_ids")
+    public void setExtractedIds(Map<String, List<String>> extractedIds) {
+        this.extractedIds = extractedIds;
+    }
+
+    public LegacyGenomeData withExtractedIds(Map<String, List<String>> extractedIds) {
+        this.extractedIds = extractedIds;
+        return this;
+    }
+
     @JsonProperty("handle_error")
     public java.lang.String getHandleError() {
         return handleError;
@@ -318,7 +354,7 @@ public class LegacyGenomeData {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((((((((((((((((((("LegacyGenomeData"+" [data=")+ data)+", info=")+ info)+", provenance=")+ provenance)+", creator=")+ creator)+", origWsid=")+ origWsid)+", copied=")+ copied)+", copySourceInaccessible=")+ copySourceInaccessible)+", created=")+ created)+", epoch=")+ epoch)+", handleError=")+ handleError)+", handleStacktrace=")+ handleStacktrace)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((((((((((((((((((((((("LegacyGenomeData"+" [data=")+ data)+", info=")+ info)+", provenance=")+ provenance)+", creator=")+ creator)+", origWsid=")+ origWsid)+", copied=")+ copied)+", copySourceInaccessible=")+ copySourceInaccessible)+", created=")+ created)+", epoch=")+ epoch)+", refs=")+ refs)+", extractedIds=")+ extractedIds)+", handleError=")+ handleError)+", handleStacktrace=")+ handleStacktrace)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/src/us/kbase/genomeannotationapi/LegacyGenomeDataSet.java
+++ b/lib/src/us/kbase/genomeannotationapi/LegacyGenomeDataSet.java
@@ -1,0 +1,61 @@
+
+package us.kbase.genomeannotationapi;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: LegacyGenomeDataSet</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "genomes"
+})
+public class LegacyGenomeDataSet {
+
+    @JsonProperty("genomes")
+    private List<LegacyGenomeData> genomes;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("genomes")
+    public List<LegacyGenomeData> getGenomes() {
+        return genomes;
+    }
+
+    @JsonProperty("genomes")
+    public void setGenomes(List<LegacyGenomeData> genomes) {
+        this.genomes = genomes;
+    }
+
+    public LegacyGenomeDataSet withGenomes(List<LegacyGenomeData> genomes) {
+        this.genomes = genomes;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((("LegacyGenomeDataSet"+" [genomes=")+ genomes)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/genomeannotationapi/LegacyGenomeSaveData.java
+++ b/lib/src/us/kbase/genomeannotationapi/LegacyGenomeSaveData.java
@@ -1,0 +1,177 @@
+
+package us.kbase.genomeannotationapi;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import us.kbase.kbasegenomes.Genome;
+import us.kbase.workspace.ProvenanceAction;
+
+
+/**
+ * <p>Original spec-file type: LegacyGenomeSaveData</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "data",
+    "hidden",
+    "provenance"
+})
+public class LegacyGenomeSaveData {
+
+    /**
+     * <p>Original spec-file type: Genome</p>
+     * <pre>
+     * Genome object holds much of the data relevant for a genome in KBase
+     *         Genome publications should be papers about the genome, not
+     *         papers about certain features of the genome (which go into the
+     *         Feature object)
+     *         Should the Genome object have a list of feature ids? (in
+     *         addition to having a list of feature_refs)
+     *         Should the Genome object contain a list of contig_ids too?
+     * @optional assembly_ref quality close_genomes analysis_events features source_id source contigs contig_ids publications md5 taxonomy gc_content complete dna_size num_contigs contig_lengths contigset_ref
+     * @metadata ws gc_content as GC content
+     * @metadata ws taxonomy as Taxonomy
+     * @metadata ws md5 as MD5
+     * @metadata ws dna_size as Size
+     * @metadata ws genetic_code as Genetic code
+     * @metadata ws domain as Domain
+     *     @metadata ws source_id as Source ID
+     *     @metadata ws source as Source
+     *     @metadata ws scientific_name as Name
+     *     @metadata ws length(close_genomes) as Close genomes
+     *     @metadata ws length(features) as Number features
+     *     @metadata ws num_contigs as Number contigs
+     * </pre>
+     * 
+     */
+    @JsonProperty("data")
+    private Genome data;
+    @JsonProperty("hidden")
+    private Long hidden;
+    @JsonProperty("provenance")
+    private List<ProvenanceAction> provenance;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    /**
+     * <p>Original spec-file type: Genome</p>
+     * <pre>
+     * Genome object holds much of the data relevant for a genome in KBase
+     *         Genome publications should be papers about the genome, not
+     *         papers about certain features of the genome (which go into the
+     *         Feature object)
+     *         Should the Genome object have a list of feature ids? (in
+     *         addition to having a list of feature_refs)
+     *         Should the Genome object contain a list of contig_ids too?
+     * @optional assembly_ref quality close_genomes analysis_events features source_id source contigs contig_ids publications md5 taxonomy gc_content complete dna_size num_contigs contig_lengths contigset_ref
+     * @metadata ws gc_content as GC content
+     * @metadata ws taxonomy as Taxonomy
+     * @metadata ws md5 as MD5
+     * @metadata ws dna_size as Size
+     * @metadata ws genetic_code as Genetic code
+     * @metadata ws domain as Domain
+     *     @metadata ws source_id as Source ID
+     *     @metadata ws source as Source
+     *     @metadata ws scientific_name as Name
+     *     @metadata ws length(close_genomes) as Close genomes
+     *     @metadata ws length(features) as Number features
+     *     @metadata ws num_contigs as Number contigs
+     * </pre>
+     * 
+     */
+    @JsonProperty("data")
+    public Genome getData() {
+        return data;
+    }
+
+    /**
+     * <p>Original spec-file type: Genome</p>
+     * <pre>
+     * Genome object holds much of the data relevant for a genome in KBase
+     *         Genome publications should be papers about the genome, not
+     *         papers about certain features of the genome (which go into the
+     *         Feature object)
+     *         Should the Genome object have a list of feature ids? (in
+     *         addition to having a list of feature_refs)
+     *         Should the Genome object contain a list of contig_ids too?
+     * @optional assembly_ref quality close_genomes analysis_events features source_id source contigs contig_ids publications md5 taxonomy gc_content complete dna_size num_contigs contig_lengths contigset_ref
+     * @metadata ws gc_content as GC content
+     * @metadata ws taxonomy as Taxonomy
+     * @metadata ws md5 as MD5
+     * @metadata ws dna_size as Size
+     * @metadata ws genetic_code as Genetic code
+     * @metadata ws domain as Domain
+     *     @metadata ws source_id as Source ID
+     *     @metadata ws source as Source
+     *     @metadata ws scientific_name as Name
+     *     @metadata ws length(close_genomes) as Close genomes
+     *     @metadata ws length(features) as Number features
+     *     @metadata ws num_contigs as Number contigs
+     * </pre>
+     * 
+     */
+    @JsonProperty("data")
+    public void setData(Genome data) {
+        this.data = data;
+    }
+
+    public LegacyGenomeSaveData withData(Genome data) {
+        this.data = data;
+        return this;
+    }
+
+    @JsonProperty("hidden")
+    public Long getHidden() {
+        return hidden;
+    }
+
+    @JsonProperty("hidden")
+    public void setHidden(Long hidden) {
+        this.hidden = hidden;
+    }
+
+    public LegacyGenomeSaveData withHidden(Long hidden) {
+        this.hidden = hidden;
+        return this;
+    }
+
+    @JsonProperty("provenance")
+    public List<ProvenanceAction> getProvenance() {
+        return provenance;
+    }
+
+    @JsonProperty("provenance")
+    public void setProvenance(List<ProvenanceAction> provenance) {
+        this.provenance = provenance;
+    }
+
+    public LegacyGenomeSaveData withProvenance(List<ProvenanceAction> provenance) {
+        this.provenance = provenance;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((("LegacyGenomeSaveData"+" [data=")+ data)+", hidden=")+ hidden)+", provenance=")+ provenance)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/genomeannotationapi/LegacyGenomeSelector.java
+++ b/lib/src/us/kbase/genomeannotationapi/LegacyGenomeSelector.java
@@ -21,15 +21,15 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 @Generated("com.googlecode.jsonschema2pojo")
 @JsonPropertyOrder({
     "ref",
-    "included",
+    "included_feature_position_index",
     "ref_path_to_genome"
 })
 public class LegacyGenomeSelector {
 
     @JsonProperty("ref")
     private java.lang.String ref;
-    @JsonProperty("included")
-    private List<String> included;
+    @JsonProperty("included_feature_position_index")
+    private List<Long> includedFeaturePositionIndex;
     @JsonProperty("ref_path_to_genome")
     private List<String> refPathToGenome;
     private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
@@ -49,18 +49,18 @@ public class LegacyGenomeSelector {
         return this;
     }
 
-    @JsonProperty("included")
-    public List<String> getIncluded() {
-        return included;
+    @JsonProperty("included_feature_position_index")
+    public List<Long> getIncludedFeaturePositionIndex() {
+        return includedFeaturePositionIndex;
     }
 
-    @JsonProperty("included")
-    public void setIncluded(List<String> included) {
-        this.included = included;
+    @JsonProperty("included_feature_position_index")
+    public void setIncludedFeaturePositionIndex(List<Long> includedFeaturePositionIndex) {
+        this.includedFeaturePositionIndex = includedFeaturePositionIndex;
     }
 
-    public LegacyGenomeSelector withIncluded(List<String> included) {
-        this.included = included;
+    public LegacyGenomeSelector withIncludedFeaturePositionIndex(List<Long> includedFeaturePositionIndex) {
+        this.includedFeaturePositionIndex = includedFeaturePositionIndex;
         return this;
     }
 
@@ -91,7 +91,7 @@ public class LegacyGenomeSelector {
 
     @Override
     public java.lang.String toString() {
-        return ((((((((("LegacyGenomeSelector"+" [ref=")+ ref)+", included=")+ included)+", refPathToGenome=")+ refPathToGenome)+", additionalProperties=")+ additionalProperties)+"]");
+        return ((((((((("LegacyGenomeSelector"+" [ref=")+ ref)+", includedFeaturePositionIndex=")+ includedFeaturePositionIndex)+", refPathToGenome=")+ refPathToGenome)+", additionalProperties=")+ additionalProperties)+"]");
     }
 
 }

--- a/lib/src/us/kbase/genomeannotationapi/LegacyGenomeSelector.java
+++ b/lib/src/us/kbase/genomeannotationapi/LegacyGenomeSelector.java
@@ -1,0 +1,97 @@
+
+package us.kbase.genomeannotationapi;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: LegacyGenomeSelector</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "ref",
+    "included",
+    "ref_path_to_genome"
+})
+public class LegacyGenomeSelector {
+
+    @JsonProperty("ref")
+    private java.lang.String ref;
+    @JsonProperty("included")
+    private List<String> included;
+    @JsonProperty("ref_path_to_genome")
+    private List<String> refPathToGenome;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("ref")
+    public java.lang.String getRef() {
+        return ref;
+    }
+
+    @JsonProperty("ref")
+    public void setRef(java.lang.String ref) {
+        this.ref = ref;
+    }
+
+    public LegacyGenomeSelector withRef(java.lang.String ref) {
+        this.ref = ref;
+        return this;
+    }
+
+    @JsonProperty("included")
+    public List<String> getIncluded() {
+        return included;
+    }
+
+    @JsonProperty("included")
+    public void setIncluded(List<String> included) {
+        this.included = included;
+    }
+
+    public LegacyGenomeSelector withIncluded(List<String> included) {
+        this.included = included;
+        return this;
+    }
+
+    @JsonProperty("ref_path_to_genome")
+    public List<String> getRefPathToGenome() {
+        return refPathToGenome;
+    }
+
+    @JsonProperty("ref_path_to_genome")
+    public void setRefPathToGenome(List<String> refPathToGenome) {
+        this.refPathToGenome = refPathToGenome;
+    }
+
+    public LegacyGenomeSelector withRefPathToGenome(List<String> refPathToGenome) {
+        this.refPathToGenome = refPathToGenome;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((((("LegacyGenomeSelector"+" [ref=")+ ref)+", included=")+ included)+", refPathToGenome=")+ refPathToGenome)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/genomeannotationapi/SaveLegacyGenomeParams.java
+++ b/lib/src/us/kbase/genomeannotationapi/SaveLegacyGenomeParams.java
@@ -1,0 +1,97 @@
+
+package us.kbase.genomeannotationapi;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: SaveLegacyGenomeParams</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "workspace",
+    "name",
+    "genomes"
+})
+public class SaveLegacyGenomeParams {
+
+    @JsonProperty("workspace")
+    private String workspace;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("genomes")
+    private List<LegacyGenomeSaveData> genomes;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("workspace")
+    public String getWorkspace() {
+        return workspace;
+    }
+
+    @JsonProperty("workspace")
+    public void setWorkspace(String workspace) {
+        this.workspace = workspace;
+    }
+
+    public SaveLegacyGenomeParams withWorkspace(String workspace) {
+        this.workspace = workspace;
+        return this;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public SaveLegacyGenomeParams withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @JsonProperty("genomes")
+    public List<LegacyGenomeSaveData> getGenomes() {
+        return genomes;
+    }
+
+    @JsonProperty("genomes")
+    public void setGenomes(List<LegacyGenomeSaveData> genomes) {
+        this.genomes = genomes;
+    }
+
+    public SaveLegacyGenomeParams withGenomes(List<LegacyGenomeSaveData> genomes) {
+        this.genomes = genomes;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((("SaveLegacyGenomeParams"+" [workspace=")+ workspace)+", name=")+ name)+", genomes=")+ genomes)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/genomeannotationapi/SaveLegacyGenomeResult.java
+++ b/lib/src/us/kbase/genomeannotationapi/SaveLegacyGenomeResult.java
@@ -1,0 +1,62 @@
+
+package us.kbase.genomeannotationapi;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import us.kbase.common.service.Tuple11;
+
+
+/**
+ * <p>Original spec-file type: SaveLegacyGenomeResult</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "info"
+})
+public class SaveLegacyGenomeResult {
+
+    @JsonProperty("info")
+    private List<Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>>> info;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("info")
+    public List<Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>>> getInfo() {
+        return info;
+    }
+
+    @JsonProperty("info")
+    public void setInfo(List<Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>>> info) {
+        this.info = info;
+    }
+
+    public SaveLegacyGenomeResult withInfo(List<Tuple11 <Long, String, String, String, Long, String, Long, String, String, Long, Map<String, String>>> info) {
+        this.info = info;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((("SaveLegacyGenomeResult"+" [info=")+ info)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/kbasegenomes/AnalysisEvent.java
+++ b/lib/src/us/kbase/kbasegenomes/AnalysisEvent.java
@@ -1,0 +1,135 @@
+
+package us.kbase.kbasegenomes;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: Analysis_event</p>
+ * <pre>
+ * @optional tool_name execution_time parameters hostname
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "id",
+    "tool_name",
+    "execution_time",
+    "parameters",
+    "hostname"
+})
+public class AnalysisEvent {
+
+    @JsonProperty("id")
+    private java.lang.String id;
+    @JsonProperty("tool_name")
+    private java.lang.String toolName;
+    @JsonProperty("execution_time")
+    private Double executionTime;
+    @JsonProperty("parameters")
+    private List<String> parameters;
+    @JsonProperty("hostname")
+    private java.lang.String hostname;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("id")
+    public java.lang.String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(java.lang.String id) {
+        this.id = id;
+    }
+
+    public AnalysisEvent withId(java.lang.String id) {
+        this.id = id;
+        return this;
+    }
+
+    @JsonProperty("tool_name")
+    public java.lang.String getToolName() {
+        return toolName;
+    }
+
+    @JsonProperty("tool_name")
+    public void setToolName(java.lang.String toolName) {
+        this.toolName = toolName;
+    }
+
+    public AnalysisEvent withToolName(java.lang.String toolName) {
+        this.toolName = toolName;
+        return this;
+    }
+
+    @JsonProperty("execution_time")
+    public Double getExecutionTime() {
+        return executionTime;
+    }
+
+    @JsonProperty("execution_time")
+    public void setExecutionTime(Double executionTime) {
+        this.executionTime = executionTime;
+    }
+
+    public AnalysisEvent withExecutionTime(Double executionTime) {
+        this.executionTime = executionTime;
+        return this;
+    }
+
+    @JsonProperty("parameters")
+    public List<String> getParameters() {
+        return parameters;
+    }
+
+    @JsonProperty("parameters")
+    public void setParameters(List<String> parameters) {
+        this.parameters = parameters;
+    }
+
+    public AnalysisEvent withParameters(List<String> parameters) {
+        this.parameters = parameters;
+        return this;
+    }
+
+    @JsonProperty("hostname")
+    public java.lang.String getHostname() {
+        return hostname;
+    }
+
+    @JsonProperty("hostname")
+    public void setHostname(java.lang.String hostname) {
+        this.hostname = hostname;
+    }
+
+    public AnalysisEvent withHostname(java.lang.String hostname) {
+        this.hostname = hostname;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((((((((("AnalysisEvent"+" [id=")+ id)+", toolName=")+ toolName)+", executionTime=")+ executionTime)+", parameters=")+ parameters)+", hostname=")+ hostname)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/kbasegenomes/CloseGenome.java
+++ b/lib/src/us/kbase/kbasegenomes/CloseGenome.java
@@ -1,0 +1,80 @@
+
+package us.kbase.kbasegenomes;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: Close_genome</p>
+ * <pre>
+ * @optional genome closeness_measure
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "genome",
+    "closeness_measure"
+})
+public class CloseGenome {
+
+    @JsonProperty("genome")
+    private String genome;
+    @JsonProperty("closeness_measure")
+    private Double closenessMeasure;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("genome")
+    public String getGenome() {
+        return genome;
+    }
+
+    @JsonProperty("genome")
+    public void setGenome(String genome) {
+        this.genome = genome;
+    }
+
+    public CloseGenome withGenome(String genome) {
+        this.genome = genome;
+        return this;
+    }
+
+    @JsonProperty("closeness_measure")
+    public Double getClosenessMeasure() {
+        return closenessMeasure;
+    }
+
+    @JsonProperty("closeness_measure")
+    public void setClosenessMeasure(Double closenessMeasure) {
+        this.closenessMeasure = closenessMeasure;
+    }
+
+    public CloseGenome withClosenessMeasure(Double closenessMeasure) {
+        this.closenessMeasure = closenessMeasure;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((("CloseGenome"+" [genome=")+ genome)+", closenessMeasure=")+ closenessMeasure)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/kbasegenomes/Contig.java
+++ b/lib/src/us/kbase/kbasegenomes/Contig.java
@@ -1,0 +1,247 @@
+
+package us.kbase.kbasegenomes;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: Contig</p>
+ * <pre>
+ * Type spec for a "Contig" subobject in the "ContigSet" object
+ *                 Contig_id id - ID of contig in contigset
+ *                 string md5 - unique hash of contig sequence
+ *                 string sequence - sequence of the contig
+ *                 string description - Description of the contig (e.g. everything after the ID in a FASTA file)
+ *                 @optional length md5 genetic_code cell_compartment replicon_geometry replicon_type name description complete
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "id",
+    "length",
+    "md5",
+    "sequence",
+    "genetic_code",
+    "cell_compartment",
+    "replicon_type",
+    "replicon_geometry",
+    "name",
+    "description",
+    "complete"
+})
+public class Contig {
+
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("length")
+    private Long length;
+    @JsonProperty("md5")
+    private String md5;
+    @JsonProperty("sequence")
+    private String sequence;
+    @JsonProperty("genetic_code")
+    private Long geneticCode;
+    @JsonProperty("cell_compartment")
+    private String cellCompartment;
+    @JsonProperty("replicon_type")
+    private String repliconType;
+    @JsonProperty("replicon_geometry")
+    private String repliconGeometry;
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("description")
+    private String description;
+    @JsonProperty("complete")
+    private Long complete;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public Contig withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    @JsonProperty("length")
+    public Long getLength() {
+        return length;
+    }
+
+    @JsonProperty("length")
+    public void setLength(Long length) {
+        this.length = length;
+    }
+
+    public Contig withLength(Long length) {
+        this.length = length;
+        return this;
+    }
+
+    @JsonProperty("md5")
+    public String getMd5() {
+        return md5;
+    }
+
+    @JsonProperty("md5")
+    public void setMd5(String md5) {
+        this.md5 = md5;
+    }
+
+    public Contig withMd5(String md5) {
+        this.md5 = md5;
+        return this;
+    }
+
+    @JsonProperty("sequence")
+    public String getSequence() {
+        return sequence;
+    }
+
+    @JsonProperty("sequence")
+    public void setSequence(String sequence) {
+        this.sequence = sequence;
+    }
+
+    public Contig withSequence(String sequence) {
+        this.sequence = sequence;
+        return this;
+    }
+
+    @JsonProperty("genetic_code")
+    public Long getGeneticCode() {
+        return geneticCode;
+    }
+
+    @JsonProperty("genetic_code")
+    public void setGeneticCode(Long geneticCode) {
+        this.geneticCode = geneticCode;
+    }
+
+    public Contig withGeneticCode(Long geneticCode) {
+        this.geneticCode = geneticCode;
+        return this;
+    }
+
+    @JsonProperty("cell_compartment")
+    public String getCellCompartment() {
+        return cellCompartment;
+    }
+
+    @JsonProperty("cell_compartment")
+    public void setCellCompartment(String cellCompartment) {
+        this.cellCompartment = cellCompartment;
+    }
+
+    public Contig withCellCompartment(String cellCompartment) {
+        this.cellCompartment = cellCompartment;
+        return this;
+    }
+
+    @JsonProperty("replicon_type")
+    public String getRepliconType() {
+        return repliconType;
+    }
+
+    @JsonProperty("replicon_type")
+    public void setRepliconType(String repliconType) {
+        this.repliconType = repliconType;
+    }
+
+    public Contig withRepliconType(String repliconType) {
+        this.repliconType = repliconType;
+        return this;
+    }
+
+    @JsonProperty("replicon_geometry")
+    public String getRepliconGeometry() {
+        return repliconGeometry;
+    }
+
+    @JsonProperty("replicon_geometry")
+    public void setRepliconGeometry(String repliconGeometry) {
+        this.repliconGeometry = repliconGeometry;
+    }
+
+    public Contig withRepliconGeometry(String repliconGeometry) {
+        this.repliconGeometry = repliconGeometry;
+        return this;
+    }
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Contig withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonProperty("description")
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Contig withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    @JsonProperty("complete")
+    public Long getComplete() {
+        return complete;
+    }
+
+    @JsonProperty("complete")
+    public void setComplete(Long complete) {
+        this.complete = complete;
+    }
+
+    public Contig withComplete(Long complete) {
+        this.complete = complete;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((((((((((((((((((("Contig"+" [id=")+ id)+", length=")+ length)+", md5=")+ md5)+", sequence=")+ sequence)+", geneticCode=")+ geneticCode)+", cellCompartment=")+ cellCompartment)+", repliconType=")+ repliconType)+", repliconGeometry=")+ repliconGeometry)+", name=")+ name)+", description=")+ description)+", complete=")+ complete)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/kbasegenomes/Feature.java
+++ b/lib/src/us/kbase/kbasegenomes/Feature.java
@@ -1,0 +1,513 @@
+
+package us.kbase.kbasegenomes;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import us.kbase.common.service.Tuple2;
+import us.kbase.common.service.Tuple3;
+import us.kbase.common.service.Tuple4;
+import us.kbase.common.service.Tuple7;
+
+
+/**
+ * <p>Original spec-file type: Feature</p>
+ * <pre>
+ * Structure for a single feature of a genome
+ *     
+ *     Should genome_id contain the genome_id in the Genome object,
+ *     the workspace id of the Genome object, a genomeref,
+ *     something else?
+ *     Should sequence be in separate objects too?
+ *     We may want to add additional fields for other CDM functions
+ *     (e.g., atomic regulons, coexpressed fids, co_occurring fids,...)
+ *     @optional orthologs quality feature_creation_event md5 location function ontology_terms protein_translation protein_families subsystems publications subsystem_data aliases annotations regulon_data atomic_regulons coexpressed_fids co_occurring_fids dna_sequence protein_translation_length dna_sequence_length
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "id",
+    "location",
+    "type",
+    "function",
+    "ontology_terms",
+    "md5",
+    "protein_translation",
+    "dna_sequence",
+    "protein_translation_length",
+    "dna_sequence_length",
+    "publications",
+    "subsystems",
+    "protein_families",
+    "aliases",
+    "orthologs",
+    "annotations",
+    "subsystem_data",
+    "regulon_data",
+    "atomic_regulons",
+    "coexpressed_fids",
+    "co_occurring_fids",
+    "quality",
+    "feature_creation_event"
+})
+public class Feature {
+
+    @JsonProperty("id")
+    private java.lang.String id;
+    @JsonProperty("location")
+    private List<Tuple4 <String, Long, String, Long>> location;
+    @JsonProperty("type")
+    private java.lang.String type;
+    @JsonProperty("function")
+    private java.lang.String function;
+    @JsonProperty("ontology_terms")
+    private Map<String, Map<String, OntologyData>> ontologyTerms;
+    @JsonProperty("md5")
+    private java.lang.String md5;
+    @JsonProperty("protein_translation")
+    private java.lang.String proteinTranslation;
+    @JsonProperty("dna_sequence")
+    private java.lang.String dnaSequence;
+    @JsonProperty("protein_translation_length")
+    private java.lang.Long proteinTranslationLength;
+    @JsonProperty("dna_sequence_length")
+    private java.lang.Long dnaSequenceLength;
+    @JsonProperty("publications")
+    private List<Tuple7 <Long, String, String, String, String, String, String>> publications;
+    @JsonProperty("subsystems")
+    private List<String> subsystems;
+    @JsonProperty("protein_families")
+    private List<ProteinFamily> proteinFamilies;
+    @JsonProperty("aliases")
+    private List<String> aliases;
+    @JsonProperty("orthologs")
+    private List<Tuple2 <String, Double>> orthologs;
+    @JsonProperty("annotations")
+    private List<Tuple3 <String, String, Double>> annotations;
+    @JsonProperty("subsystem_data")
+    private List<Tuple3 <String, String, String>> subsystemData;
+    @JsonProperty("regulon_data")
+    private List<Tuple3 <String, List<String> , List<String>>> regulonData;
+    @JsonProperty("atomic_regulons")
+    private List<Tuple2 <String, Long>> atomicRegulons;
+    @JsonProperty("coexpressed_fids")
+    private List<Tuple2 <String, Double>> coexpressedFids;
+    @JsonProperty("co_occurring_fids")
+    private List<Tuple2 <String, Double>> coOccurringFids;
+    /**
+     * <p>Original spec-file type: Feature_quality_measure</p>
+     * <pre>
+     * @optional weighted_hit_count hit_count existence_priority overlap_rules pyrrolysylprotein truncated_begin truncated_end existence_confidence frameshifted selenoprotein
+     * </pre>
+     * 
+     */
+    @JsonProperty("quality")
+    private FeatureQualityMeasure quality;
+    /**
+     * <p>Original spec-file type: Analysis_event</p>
+     * <pre>
+     * @optional tool_name execution_time parameters hostname
+     * </pre>
+     * 
+     */
+    @JsonProperty("feature_creation_event")
+    private AnalysisEvent featureCreationEvent;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("id")
+    public java.lang.String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(java.lang.String id) {
+        this.id = id;
+    }
+
+    public Feature withId(java.lang.String id) {
+        this.id = id;
+        return this;
+    }
+
+    @JsonProperty("location")
+    public List<Tuple4 <String, Long, String, Long>> getLocation() {
+        return location;
+    }
+
+    @JsonProperty("location")
+    public void setLocation(List<Tuple4 <String, Long, String, Long>> location) {
+        this.location = location;
+    }
+
+    public Feature withLocation(List<Tuple4 <String, Long, String, Long>> location) {
+        this.location = location;
+        return this;
+    }
+
+    @JsonProperty("type")
+    public java.lang.String getType() {
+        return type;
+    }
+
+    @JsonProperty("type")
+    public void setType(java.lang.String type) {
+        this.type = type;
+    }
+
+    public Feature withType(java.lang.String type) {
+        this.type = type;
+        return this;
+    }
+
+    @JsonProperty("function")
+    public java.lang.String getFunction() {
+        return function;
+    }
+
+    @JsonProperty("function")
+    public void setFunction(java.lang.String function) {
+        this.function = function;
+    }
+
+    public Feature withFunction(java.lang.String function) {
+        this.function = function;
+        return this;
+    }
+
+    @JsonProperty("ontology_terms")
+    public Map<String, Map<String, OntologyData>> getOntologyTerms() {
+        return ontologyTerms;
+    }
+
+    @JsonProperty("ontology_terms")
+    public void setOntologyTerms(Map<String, Map<String, OntologyData>> ontologyTerms) {
+        this.ontologyTerms = ontologyTerms;
+    }
+
+    public Feature withOntologyTerms(Map<String, Map<String, OntologyData>> ontologyTerms) {
+        this.ontologyTerms = ontologyTerms;
+        return this;
+    }
+
+    @JsonProperty("md5")
+    public java.lang.String getMd5() {
+        return md5;
+    }
+
+    @JsonProperty("md5")
+    public void setMd5(java.lang.String md5) {
+        this.md5 = md5;
+    }
+
+    public Feature withMd5(java.lang.String md5) {
+        this.md5 = md5;
+        return this;
+    }
+
+    @JsonProperty("protein_translation")
+    public java.lang.String getProteinTranslation() {
+        return proteinTranslation;
+    }
+
+    @JsonProperty("protein_translation")
+    public void setProteinTranslation(java.lang.String proteinTranslation) {
+        this.proteinTranslation = proteinTranslation;
+    }
+
+    public Feature withProteinTranslation(java.lang.String proteinTranslation) {
+        this.proteinTranslation = proteinTranslation;
+        return this;
+    }
+
+    @JsonProperty("dna_sequence")
+    public java.lang.String getDnaSequence() {
+        return dnaSequence;
+    }
+
+    @JsonProperty("dna_sequence")
+    public void setDnaSequence(java.lang.String dnaSequence) {
+        this.dnaSequence = dnaSequence;
+    }
+
+    public Feature withDnaSequence(java.lang.String dnaSequence) {
+        this.dnaSequence = dnaSequence;
+        return this;
+    }
+
+    @JsonProperty("protein_translation_length")
+    public java.lang.Long getProteinTranslationLength() {
+        return proteinTranslationLength;
+    }
+
+    @JsonProperty("protein_translation_length")
+    public void setProteinTranslationLength(java.lang.Long proteinTranslationLength) {
+        this.proteinTranslationLength = proteinTranslationLength;
+    }
+
+    public Feature withProteinTranslationLength(java.lang.Long proteinTranslationLength) {
+        this.proteinTranslationLength = proteinTranslationLength;
+        return this;
+    }
+
+    @JsonProperty("dna_sequence_length")
+    public java.lang.Long getDnaSequenceLength() {
+        return dnaSequenceLength;
+    }
+
+    @JsonProperty("dna_sequence_length")
+    public void setDnaSequenceLength(java.lang.Long dnaSequenceLength) {
+        this.dnaSequenceLength = dnaSequenceLength;
+    }
+
+    public Feature withDnaSequenceLength(java.lang.Long dnaSequenceLength) {
+        this.dnaSequenceLength = dnaSequenceLength;
+        return this;
+    }
+
+    @JsonProperty("publications")
+    public List<Tuple7 <Long, String, String, String, String, String, String>> getPublications() {
+        return publications;
+    }
+
+    @JsonProperty("publications")
+    public void setPublications(List<Tuple7 <Long, String, String, String, String, String, String>> publications) {
+        this.publications = publications;
+    }
+
+    public Feature withPublications(List<Tuple7 <Long, String, String, String, String, String, String>> publications) {
+        this.publications = publications;
+        return this;
+    }
+
+    @JsonProperty("subsystems")
+    public List<String> getSubsystems() {
+        return subsystems;
+    }
+
+    @JsonProperty("subsystems")
+    public void setSubsystems(List<String> subsystems) {
+        this.subsystems = subsystems;
+    }
+
+    public Feature withSubsystems(List<String> subsystems) {
+        this.subsystems = subsystems;
+        return this;
+    }
+
+    @JsonProperty("protein_families")
+    public List<ProteinFamily> getProteinFamilies() {
+        return proteinFamilies;
+    }
+
+    @JsonProperty("protein_families")
+    public void setProteinFamilies(List<ProteinFamily> proteinFamilies) {
+        this.proteinFamilies = proteinFamilies;
+    }
+
+    public Feature withProteinFamilies(List<ProteinFamily> proteinFamilies) {
+        this.proteinFamilies = proteinFamilies;
+        return this;
+    }
+
+    @JsonProperty("aliases")
+    public List<String> getAliases() {
+        return aliases;
+    }
+
+    @JsonProperty("aliases")
+    public void setAliases(List<String> aliases) {
+        this.aliases = aliases;
+    }
+
+    public Feature withAliases(List<String> aliases) {
+        this.aliases = aliases;
+        return this;
+    }
+
+    @JsonProperty("orthologs")
+    public List<Tuple2 <String, Double>> getOrthologs() {
+        return orthologs;
+    }
+
+    @JsonProperty("orthologs")
+    public void setOrthologs(List<Tuple2 <String, Double>> orthologs) {
+        this.orthologs = orthologs;
+    }
+
+    public Feature withOrthologs(List<Tuple2 <String, Double>> orthologs) {
+        this.orthologs = orthologs;
+        return this;
+    }
+
+    @JsonProperty("annotations")
+    public List<Tuple3 <String, String, Double>> getAnnotations() {
+        return annotations;
+    }
+
+    @JsonProperty("annotations")
+    public void setAnnotations(List<Tuple3 <String, String, Double>> annotations) {
+        this.annotations = annotations;
+    }
+
+    public Feature withAnnotations(List<Tuple3 <String, String, Double>> annotations) {
+        this.annotations = annotations;
+        return this;
+    }
+
+    @JsonProperty("subsystem_data")
+    public List<Tuple3 <String, String, String>> getSubsystemData() {
+        return subsystemData;
+    }
+
+    @JsonProperty("subsystem_data")
+    public void setSubsystemData(List<Tuple3 <String, String, String>> subsystemData) {
+        this.subsystemData = subsystemData;
+    }
+
+    public Feature withSubsystemData(List<Tuple3 <String, String, String>> subsystemData) {
+        this.subsystemData = subsystemData;
+        return this;
+    }
+
+    @JsonProperty("regulon_data")
+    public List<Tuple3 <String, List<String> , List<String>>> getRegulonData() {
+        return regulonData;
+    }
+
+    @JsonProperty("regulon_data")
+    public void setRegulonData(List<Tuple3 <String, List<String> , List<String>>> regulonData) {
+        this.regulonData = regulonData;
+    }
+
+    public Feature withRegulonData(List<Tuple3 <String, List<String> , List<String>>> regulonData) {
+        this.regulonData = regulonData;
+        return this;
+    }
+
+    @JsonProperty("atomic_regulons")
+    public List<Tuple2 <String, Long>> getAtomicRegulons() {
+        return atomicRegulons;
+    }
+
+    @JsonProperty("atomic_regulons")
+    public void setAtomicRegulons(List<Tuple2 <String, Long>> atomicRegulons) {
+        this.atomicRegulons = atomicRegulons;
+    }
+
+    public Feature withAtomicRegulons(List<Tuple2 <String, Long>> atomicRegulons) {
+        this.atomicRegulons = atomicRegulons;
+        return this;
+    }
+
+    @JsonProperty("coexpressed_fids")
+    public List<Tuple2 <String, Double>> getCoexpressedFids() {
+        return coexpressedFids;
+    }
+
+    @JsonProperty("coexpressed_fids")
+    public void setCoexpressedFids(List<Tuple2 <String, Double>> coexpressedFids) {
+        this.coexpressedFids = coexpressedFids;
+    }
+
+    public Feature withCoexpressedFids(List<Tuple2 <String, Double>> coexpressedFids) {
+        this.coexpressedFids = coexpressedFids;
+        return this;
+    }
+
+    @JsonProperty("co_occurring_fids")
+    public List<Tuple2 <String, Double>> getCoOccurringFids() {
+        return coOccurringFids;
+    }
+
+    @JsonProperty("co_occurring_fids")
+    public void setCoOccurringFids(List<Tuple2 <String, Double>> coOccurringFids) {
+        this.coOccurringFids = coOccurringFids;
+    }
+
+    public Feature withCoOccurringFids(List<Tuple2 <String, Double>> coOccurringFids) {
+        this.coOccurringFids = coOccurringFids;
+        return this;
+    }
+
+    /**
+     * <p>Original spec-file type: Feature_quality_measure</p>
+     * <pre>
+     * @optional weighted_hit_count hit_count existence_priority overlap_rules pyrrolysylprotein truncated_begin truncated_end existence_confidence frameshifted selenoprotein
+     * </pre>
+     * 
+     */
+    @JsonProperty("quality")
+    public FeatureQualityMeasure getQuality() {
+        return quality;
+    }
+
+    /**
+     * <p>Original spec-file type: Feature_quality_measure</p>
+     * <pre>
+     * @optional weighted_hit_count hit_count existence_priority overlap_rules pyrrolysylprotein truncated_begin truncated_end existence_confidence frameshifted selenoprotein
+     * </pre>
+     * 
+     */
+    @JsonProperty("quality")
+    public void setQuality(FeatureQualityMeasure quality) {
+        this.quality = quality;
+    }
+
+    public Feature withQuality(FeatureQualityMeasure quality) {
+        this.quality = quality;
+        return this;
+    }
+
+    /**
+     * <p>Original spec-file type: Analysis_event</p>
+     * <pre>
+     * @optional tool_name execution_time parameters hostname
+     * </pre>
+     * 
+     */
+    @JsonProperty("feature_creation_event")
+    public AnalysisEvent getFeatureCreationEvent() {
+        return featureCreationEvent;
+    }
+
+    /**
+     * <p>Original spec-file type: Analysis_event</p>
+     * <pre>
+     * @optional tool_name execution_time parameters hostname
+     * </pre>
+     * 
+     */
+    @JsonProperty("feature_creation_event")
+    public void setFeatureCreationEvent(AnalysisEvent featureCreationEvent) {
+        this.featureCreationEvent = featureCreationEvent;
+    }
+
+    public Feature withFeatureCreationEvent(AnalysisEvent featureCreationEvent) {
+        this.featureCreationEvent = featureCreationEvent;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((((((((((((((((((((((((((((((((((((((((((((("Feature"+" [id=")+ id)+", location=")+ location)+", type=")+ type)+", function=")+ function)+", ontologyTerms=")+ ontologyTerms)+", md5=")+ md5)+", proteinTranslation=")+ proteinTranslation)+", dnaSequence=")+ dnaSequence)+", proteinTranslationLength=")+ proteinTranslationLength)+", dnaSequenceLength=")+ dnaSequenceLength)+", publications=")+ publications)+", subsystems=")+ subsystems)+", proteinFamilies=")+ proteinFamilies)+", aliases=")+ aliases)+", orthologs=")+ orthologs)+", annotations=")+ annotations)+", subsystemData=")+ subsystemData)+", regulonData=")+ regulonData)+", atomicRegulons=")+ atomicRegulons)+", coexpressedFids=")+ coexpressedFids)+", coOccurringFids=")+ coOccurringFids)+", quality=")+ quality)+", featureCreationEvent=")+ featureCreationEvent)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/kbasegenomes/FeatureQualityMeasure.java
+++ b/lib/src/us/kbase/kbasegenomes/FeatureQualityMeasure.java
@@ -1,0 +1,225 @@
+
+package us.kbase.kbasegenomes;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: Feature_quality_measure</p>
+ * <pre>
+ * @optional weighted_hit_count hit_count existence_priority overlap_rules pyrrolysylprotein truncated_begin truncated_end existence_confidence frameshifted selenoprotein
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "truncated_begin",
+    "truncated_end",
+    "existence_confidence",
+    "frameshifted",
+    "selenoprotein",
+    "pyrrolysylprotein",
+    "overlap_rules",
+    "existence_priority",
+    "hit_count",
+    "weighted_hit_count"
+})
+public class FeatureQualityMeasure {
+
+    @JsonProperty("truncated_begin")
+    private Long truncatedBegin;
+    @JsonProperty("truncated_end")
+    private Long truncatedEnd;
+    @JsonProperty("existence_confidence")
+    private Double existenceConfidence;
+    @JsonProperty("frameshifted")
+    private Long frameshifted;
+    @JsonProperty("selenoprotein")
+    private Long selenoprotein;
+    @JsonProperty("pyrrolysylprotein")
+    private Long pyrrolysylprotein;
+    @JsonProperty("overlap_rules")
+    private List<String> overlapRules;
+    @JsonProperty("existence_priority")
+    private Double existencePriority;
+    @JsonProperty("hit_count")
+    private Double hitCount;
+    @JsonProperty("weighted_hit_count")
+    private Double weightedHitCount;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("truncated_begin")
+    public Long getTruncatedBegin() {
+        return truncatedBegin;
+    }
+
+    @JsonProperty("truncated_begin")
+    public void setTruncatedBegin(Long truncatedBegin) {
+        this.truncatedBegin = truncatedBegin;
+    }
+
+    public FeatureQualityMeasure withTruncatedBegin(Long truncatedBegin) {
+        this.truncatedBegin = truncatedBegin;
+        return this;
+    }
+
+    @JsonProperty("truncated_end")
+    public Long getTruncatedEnd() {
+        return truncatedEnd;
+    }
+
+    @JsonProperty("truncated_end")
+    public void setTruncatedEnd(Long truncatedEnd) {
+        this.truncatedEnd = truncatedEnd;
+    }
+
+    public FeatureQualityMeasure withTruncatedEnd(Long truncatedEnd) {
+        this.truncatedEnd = truncatedEnd;
+        return this;
+    }
+
+    @JsonProperty("existence_confidence")
+    public Double getExistenceConfidence() {
+        return existenceConfidence;
+    }
+
+    @JsonProperty("existence_confidence")
+    public void setExistenceConfidence(Double existenceConfidence) {
+        this.existenceConfidence = existenceConfidence;
+    }
+
+    public FeatureQualityMeasure withExistenceConfidence(Double existenceConfidence) {
+        this.existenceConfidence = existenceConfidence;
+        return this;
+    }
+
+    @JsonProperty("frameshifted")
+    public Long getFrameshifted() {
+        return frameshifted;
+    }
+
+    @JsonProperty("frameshifted")
+    public void setFrameshifted(Long frameshifted) {
+        this.frameshifted = frameshifted;
+    }
+
+    public FeatureQualityMeasure withFrameshifted(Long frameshifted) {
+        this.frameshifted = frameshifted;
+        return this;
+    }
+
+    @JsonProperty("selenoprotein")
+    public Long getSelenoprotein() {
+        return selenoprotein;
+    }
+
+    @JsonProperty("selenoprotein")
+    public void setSelenoprotein(Long selenoprotein) {
+        this.selenoprotein = selenoprotein;
+    }
+
+    public FeatureQualityMeasure withSelenoprotein(Long selenoprotein) {
+        this.selenoprotein = selenoprotein;
+        return this;
+    }
+
+    @JsonProperty("pyrrolysylprotein")
+    public Long getPyrrolysylprotein() {
+        return pyrrolysylprotein;
+    }
+
+    @JsonProperty("pyrrolysylprotein")
+    public void setPyrrolysylprotein(Long pyrrolysylprotein) {
+        this.pyrrolysylprotein = pyrrolysylprotein;
+    }
+
+    public FeatureQualityMeasure withPyrrolysylprotein(Long pyrrolysylprotein) {
+        this.pyrrolysylprotein = pyrrolysylprotein;
+        return this;
+    }
+
+    @JsonProperty("overlap_rules")
+    public List<String> getOverlapRules() {
+        return overlapRules;
+    }
+
+    @JsonProperty("overlap_rules")
+    public void setOverlapRules(List<String> overlapRules) {
+        this.overlapRules = overlapRules;
+    }
+
+    public FeatureQualityMeasure withOverlapRules(List<String> overlapRules) {
+        this.overlapRules = overlapRules;
+        return this;
+    }
+
+    @JsonProperty("existence_priority")
+    public Double getExistencePriority() {
+        return existencePriority;
+    }
+
+    @JsonProperty("existence_priority")
+    public void setExistencePriority(Double existencePriority) {
+        this.existencePriority = existencePriority;
+    }
+
+    public FeatureQualityMeasure withExistencePriority(Double existencePriority) {
+        this.existencePriority = existencePriority;
+        return this;
+    }
+
+    @JsonProperty("hit_count")
+    public Double getHitCount() {
+        return hitCount;
+    }
+
+    @JsonProperty("hit_count")
+    public void setHitCount(Double hitCount) {
+        this.hitCount = hitCount;
+    }
+
+    public FeatureQualityMeasure withHitCount(Double hitCount) {
+        this.hitCount = hitCount;
+        return this;
+    }
+
+    @JsonProperty("weighted_hit_count")
+    public Double getWeightedHitCount() {
+        return weightedHitCount;
+    }
+
+    @JsonProperty("weighted_hit_count")
+    public void setWeightedHitCount(Double weightedHitCount) {
+        this.weightedHitCount = weightedHitCount;
+    }
+
+    public FeatureQualityMeasure withWeightedHitCount(Double weightedHitCount) {
+        this.weightedHitCount = weightedHitCount;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((((((((((((((((((("FeatureQualityMeasure"+" [truncatedBegin=")+ truncatedBegin)+", truncatedEnd=")+ truncatedEnd)+", existenceConfidence=")+ existenceConfidence)+", frameshifted=")+ frameshifted)+", selenoprotein=")+ selenoprotein)+", pyrrolysylprotein=")+ pyrrolysylprotein)+", overlapRules=")+ overlapRules)+", existencePriority=")+ existencePriority)+", hitCount=")+ hitCount)+", weightedHitCount=")+ weightedHitCount)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/kbasegenomes/Genome.java
+++ b/lib/src/us/kbase/kbasegenomes/Genome.java
@@ -1,0 +1,482 @@
+
+package us.kbase.kbasegenomes;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import us.kbase.common.service.Tuple7;
+
+
+/**
+ * <p>Original spec-file type: Genome</p>
+ * <pre>
+ * Genome object holds much of the data relevant for a genome in KBase
+ *         Genome publications should be papers about the genome, not
+ *         papers about certain features of the genome (which go into the
+ *         Feature object)
+ *         Should the Genome object have a list of feature ids? (in
+ *         addition to having a list of feature_refs)
+ *         Should the Genome object contain a list of contig_ids too?
+ * @optional assembly_ref quality close_genomes analysis_events features source_id source contigs contig_ids publications md5 taxonomy gc_content complete dna_size num_contigs contig_lengths contigset_ref
+ * @metadata ws gc_content as GC content
+ * @metadata ws taxonomy as Taxonomy
+ * @metadata ws md5 as MD5
+ * @metadata ws dna_size as Size
+ * @metadata ws genetic_code as Genetic code
+ * @metadata ws domain as Domain
+ *     @metadata ws source_id as Source ID
+ *     @metadata ws source as Source
+ *     @metadata ws scientific_name as Name
+ *     @metadata ws length(close_genomes) as Close genomes
+ *     @metadata ws length(features) as Number features
+ *     @metadata ws num_contigs as Number contigs
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "id",
+    "scientific_name",
+    "domain",
+    "genetic_code",
+    "dna_size",
+    "num_contigs",
+    "contigs",
+    "contig_lengths",
+    "contig_ids",
+    "source",
+    "source_id",
+    "md5",
+    "taxonomy",
+    "gc_content",
+    "complete",
+    "publications",
+    "features",
+    "contigset_ref",
+    "assembly_ref",
+    "quality",
+    "close_genomes",
+    "analysis_events"
+})
+public class Genome {
+
+    @JsonProperty("id")
+    private java.lang.String id;
+    @JsonProperty("scientific_name")
+    private java.lang.String scientificName;
+    @JsonProperty("domain")
+    private java.lang.String domain;
+    @JsonProperty("genetic_code")
+    private java.lang.Long geneticCode;
+    @JsonProperty("dna_size")
+    private java.lang.Long dnaSize;
+    @JsonProperty("num_contigs")
+    private java.lang.Long numContigs;
+    @JsonProperty("contigs")
+    private List<Contig> contigs;
+    @JsonProperty("contig_lengths")
+    private List<Long> contigLengths;
+    @JsonProperty("contig_ids")
+    private List<String> contigIds;
+    @JsonProperty("source")
+    private java.lang.String source;
+    @JsonProperty("source_id")
+    private java.lang.String sourceId;
+    @JsonProperty("md5")
+    private java.lang.String md5;
+    @JsonProperty("taxonomy")
+    private java.lang.String taxonomy;
+    @JsonProperty("gc_content")
+    private Double gcContent;
+    @JsonProperty("complete")
+    private java.lang.Long complete;
+    @JsonProperty("publications")
+    private List<Tuple7 <Long, String, String, String, String, String, String>> publications;
+    @JsonProperty("features")
+    private List<Feature> features;
+    @JsonProperty("contigset_ref")
+    private java.lang.String contigsetRef;
+    @JsonProperty("assembly_ref")
+    private java.lang.String assemblyRef;
+    /**
+     * <p>Original spec-file type: Genome_quality_measure</p>
+     * <pre>
+     * @optional frameshift_error_rate sequence_error_rate
+     * </pre>
+     * 
+     */
+    @JsonProperty("quality")
+    private GenomeQualityMeasure quality;
+    @JsonProperty("close_genomes")
+    private List<CloseGenome> closeGenomes;
+    @JsonProperty("analysis_events")
+    private List<AnalysisEvent> analysisEvents;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("id")
+    public java.lang.String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(java.lang.String id) {
+        this.id = id;
+    }
+
+    public Genome withId(java.lang.String id) {
+        this.id = id;
+        return this;
+    }
+
+    @JsonProperty("scientific_name")
+    public java.lang.String getScientificName() {
+        return scientificName;
+    }
+
+    @JsonProperty("scientific_name")
+    public void setScientificName(java.lang.String scientificName) {
+        this.scientificName = scientificName;
+    }
+
+    public Genome withScientificName(java.lang.String scientificName) {
+        this.scientificName = scientificName;
+        return this;
+    }
+
+    @JsonProperty("domain")
+    public java.lang.String getDomain() {
+        return domain;
+    }
+
+    @JsonProperty("domain")
+    public void setDomain(java.lang.String domain) {
+        this.domain = domain;
+    }
+
+    public Genome withDomain(java.lang.String domain) {
+        this.domain = domain;
+        return this;
+    }
+
+    @JsonProperty("genetic_code")
+    public java.lang.Long getGeneticCode() {
+        return geneticCode;
+    }
+
+    @JsonProperty("genetic_code")
+    public void setGeneticCode(java.lang.Long geneticCode) {
+        this.geneticCode = geneticCode;
+    }
+
+    public Genome withGeneticCode(java.lang.Long geneticCode) {
+        this.geneticCode = geneticCode;
+        return this;
+    }
+
+    @JsonProperty("dna_size")
+    public java.lang.Long getDnaSize() {
+        return dnaSize;
+    }
+
+    @JsonProperty("dna_size")
+    public void setDnaSize(java.lang.Long dnaSize) {
+        this.dnaSize = dnaSize;
+    }
+
+    public Genome withDnaSize(java.lang.Long dnaSize) {
+        this.dnaSize = dnaSize;
+        return this;
+    }
+
+    @JsonProperty("num_contigs")
+    public java.lang.Long getNumContigs() {
+        return numContigs;
+    }
+
+    @JsonProperty("num_contigs")
+    public void setNumContigs(java.lang.Long numContigs) {
+        this.numContigs = numContigs;
+    }
+
+    public Genome withNumContigs(java.lang.Long numContigs) {
+        this.numContigs = numContigs;
+        return this;
+    }
+
+    @JsonProperty("contigs")
+    public List<Contig> getContigs() {
+        return contigs;
+    }
+
+    @JsonProperty("contigs")
+    public void setContigs(List<Contig> contigs) {
+        this.contigs = contigs;
+    }
+
+    public Genome withContigs(List<Contig> contigs) {
+        this.contigs = contigs;
+        return this;
+    }
+
+    @JsonProperty("contig_lengths")
+    public List<Long> getContigLengths() {
+        return contigLengths;
+    }
+
+    @JsonProperty("contig_lengths")
+    public void setContigLengths(List<Long> contigLengths) {
+        this.contigLengths = contigLengths;
+    }
+
+    public Genome withContigLengths(List<Long> contigLengths) {
+        this.contigLengths = contigLengths;
+        return this;
+    }
+
+    @JsonProperty("contig_ids")
+    public List<String> getContigIds() {
+        return contigIds;
+    }
+
+    @JsonProperty("contig_ids")
+    public void setContigIds(List<String> contigIds) {
+        this.contigIds = contigIds;
+    }
+
+    public Genome withContigIds(List<String> contigIds) {
+        this.contigIds = contigIds;
+        return this;
+    }
+
+    @JsonProperty("source")
+    public java.lang.String getSource() {
+        return source;
+    }
+
+    @JsonProperty("source")
+    public void setSource(java.lang.String source) {
+        this.source = source;
+    }
+
+    public Genome withSource(java.lang.String source) {
+        this.source = source;
+        return this;
+    }
+
+    @JsonProperty("source_id")
+    public java.lang.String getSourceId() {
+        return sourceId;
+    }
+
+    @JsonProperty("source_id")
+    public void setSourceId(java.lang.String sourceId) {
+        this.sourceId = sourceId;
+    }
+
+    public Genome withSourceId(java.lang.String sourceId) {
+        this.sourceId = sourceId;
+        return this;
+    }
+
+    @JsonProperty("md5")
+    public java.lang.String getMd5() {
+        return md5;
+    }
+
+    @JsonProperty("md5")
+    public void setMd5(java.lang.String md5) {
+        this.md5 = md5;
+    }
+
+    public Genome withMd5(java.lang.String md5) {
+        this.md5 = md5;
+        return this;
+    }
+
+    @JsonProperty("taxonomy")
+    public java.lang.String getTaxonomy() {
+        return taxonomy;
+    }
+
+    @JsonProperty("taxonomy")
+    public void setTaxonomy(java.lang.String taxonomy) {
+        this.taxonomy = taxonomy;
+    }
+
+    public Genome withTaxonomy(java.lang.String taxonomy) {
+        this.taxonomy = taxonomy;
+        return this;
+    }
+
+    @JsonProperty("gc_content")
+    public Double getGcContent() {
+        return gcContent;
+    }
+
+    @JsonProperty("gc_content")
+    public void setGcContent(Double gcContent) {
+        this.gcContent = gcContent;
+    }
+
+    public Genome withGcContent(Double gcContent) {
+        this.gcContent = gcContent;
+        return this;
+    }
+
+    @JsonProperty("complete")
+    public java.lang.Long getComplete() {
+        return complete;
+    }
+
+    @JsonProperty("complete")
+    public void setComplete(java.lang.Long complete) {
+        this.complete = complete;
+    }
+
+    public Genome withComplete(java.lang.Long complete) {
+        this.complete = complete;
+        return this;
+    }
+
+    @JsonProperty("publications")
+    public List<Tuple7 <Long, String, String, String, String, String, String>> getPublications() {
+        return publications;
+    }
+
+    @JsonProperty("publications")
+    public void setPublications(List<Tuple7 <Long, String, String, String, String, String, String>> publications) {
+        this.publications = publications;
+    }
+
+    public Genome withPublications(List<Tuple7 <Long, String, String, String, String, String, String>> publications) {
+        this.publications = publications;
+        return this;
+    }
+
+    @JsonProperty("features")
+    public List<Feature> getFeatures() {
+        return features;
+    }
+
+    @JsonProperty("features")
+    public void setFeatures(List<Feature> features) {
+        this.features = features;
+    }
+
+    public Genome withFeatures(List<Feature> features) {
+        this.features = features;
+        return this;
+    }
+
+    @JsonProperty("contigset_ref")
+    public java.lang.String getContigsetRef() {
+        return contigsetRef;
+    }
+
+    @JsonProperty("contigset_ref")
+    public void setContigsetRef(java.lang.String contigsetRef) {
+        this.contigsetRef = contigsetRef;
+    }
+
+    public Genome withContigsetRef(java.lang.String contigsetRef) {
+        this.contigsetRef = contigsetRef;
+        return this;
+    }
+
+    @JsonProperty("assembly_ref")
+    public java.lang.String getAssemblyRef() {
+        return assemblyRef;
+    }
+
+    @JsonProperty("assembly_ref")
+    public void setAssemblyRef(java.lang.String assemblyRef) {
+        this.assemblyRef = assemblyRef;
+    }
+
+    public Genome withAssemblyRef(java.lang.String assemblyRef) {
+        this.assemblyRef = assemblyRef;
+        return this;
+    }
+
+    /**
+     * <p>Original spec-file type: Genome_quality_measure</p>
+     * <pre>
+     * @optional frameshift_error_rate sequence_error_rate
+     * </pre>
+     * 
+     */
+    @JsonProperty("quality")
+    public GenomeQualityMeasure getQuality() {
+        return quality;
+    }
+
+    /**
+     * <p>Original spec-file type: Genome_quality_measure</p>
+     * <pre>
+     * @optional frameshift_error_rate sequence_error_rate
+     * </pre>
+     * 
+     */
+    @JsonProperty("quality")
+    public void setQuality(GenomeQualityMeasure quality) {
+        this.quality = quality;
+    }
+
+    public Genome withQuality(GenomeQualityMeasure quality) {
+        this.quality = quality;
+        return this;
+    }
+
+    @JsonProperty("close_genomes")
+    public List<CloseGenome> getCloseGenomes() {
+        return closeGenomes;
+    }
+
+    @JsonProperty("close_genomes")
+    public void setCloseGenomes(List<CloseGenome> closeGenomes) {
+        this.closeGenomes = closeGenomes;
+    }
+
+    public Genome withCloseGenomes(List<CloseGenome> closeGenomes) {
+        this.closeGenomes = closeGenomes;
+        return this;
+    }
+
+    @JsonProperty("analysis_events")
+    public List<AnalysisEvent> getAnalysisEvents() {
+        return analysisEvents;
+    }
+
+    @JsonProperty("analysis_events")
+    public void setAnalysisEvents(List<AnalysisEvent> analysisEvents) {
+        this.analysisEvents = analysisEvents;
+    }
+
+    public Genome withAnalysisEvents(List<AnalysisEvent> analysisEvents) {
+        this.analysisEvents = analysisEvents;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((((((((((((((((((((((((((((((((((((((((((("Genome"+" [id=")+ id)+", scientificName=")+ scientificName)+", domain=")+ domain)+", geneticCode=")+ geneticCode)+", dnaSize=")+ dnaSize)+", numContigs=")+ numContigs)+", contigs=")+ contigs)+", contigLengths=")+ contigLengths)+", contigIds=")+ contigIds)+", source=")+ source)+", sourceId=")+ sourceId)+", md5=")+ md5)+", taxonomy=")+ taxonomy)+", gcContent=")+ gcContent)+", complete=")+ complete)+", publications=")+ publications)+", features=")+ features)+", contigsetRef=")+ contigsetRef)+", assemblyRef=")+ assemblyRef)+", quality=")+ quality)+", closeGenomes=")+ closeGenomes)+", analysisEvents=")+ analysisEvents)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/kbasegenomes/GenomeQualityMeasure.java
+++ b/lib/src/us/kbase/kbasegenomes/GenomeQualityMeasure.java
@@ -1,0 +1,80 @@
+
+package us.kbase.kbasegenomes;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: Genome_quality_measure</p>
+ * <pre>
+ * @optional frameshift_error_rate sequence_error_rate
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "frameshift_error_rate",
+    "sequence_error_rate"
+})
+public class GenomeQualityMeasure {
+
+    @JsonProperty("frameshift_error_rate")
+    private Double frameshiftErrorRate;
+    @JsonProperty("sequence_error_rate")
+    private Double sequenceErrorRate;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("frameshift_error_rate")
+    public Double getFrameshiftErrorRate() {
+        return frameshiftErrorRate;
+    }
+
+    @JsonProperty("frameshift_error_rate")
+    public void setFrameshiftErrorRate(Double frameshiftErrorRate) {
+        this.frameshiftErrorRate = frameshiftErrorRate;
+    }
+
+    public GenomeQualityMeasure withFrameshiftErrorRate(Double frameshiftErrorRate) {
+        this.frameshiftErrorRate = frameshiftErrorRate;
+        return this;
+    }
+
+    @JsonProperty("sequence_error_rate")
+    public Double getSequenceErrorRate() {
+        return sequenceErrorRate;
+    }
+
+    @JsonProperty("sequence_error_rate")
+    public void setSequenceErrorRate(Double sequenceErrorRate) {
+        this.sequenceErrorRate = sequenceErrorRate;
+    }
+
+    public GenomeQualityMeasure withSequenceErrorRate(Double sequenceErrorRate) {
+        this.sequenceErrorRate = sequenceErrorRate;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((("GenomeQualityMeasure"+" [frameshiftErrorRate=")+ frameshiftErrorRate)+", sequenceErrorRate=")+ sequenceErrorRate)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/kbasegenomes/OntologyData.java
+++ b/lib/src/us/kbase/kbasegenomes/OntologyData.java
@@ -1,0 +1,133 @@
+
+package us.kbase.kbasegenomes;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: OntologyData</p>
+ * 
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "id",
+    "ontology_ref",
+    "term_lineage",
+    "term_name",
+    "evidence"
+})
+public class OntologyData {
+
+    @JsonProperty("id")
+    private java.lang.String id;
+    @JsonProperty("ontology_ref")
+    private java.lang.String ontologyRef;
+    @JsonProperty("term_lineage")
+    private List<String> termLineage;
+    @JsonProperty("term_name")
+    private java.lang.String termName;
+    @JsonProperty("evidence")
+    private List<OntologyEvidence> evidence;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("id")
+    public java.lang.String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(java.lang.String id) {
+        this.id = id;
+    }
+
+    public OntologyData withId(java.lang.String id) {
+        this.id = id;
+        return this;
+    }
+
+    @JsonProperty("ontology_ref")
+    public java.lang.String getOntologyRef() {
+        return ontologyRef;
+    }
+
+    @JsonProperty("ontology_ref")
+    public void setOntologyRef(java.lang.String ontologyRef) {
+        this.ontologyRef = ontologyRef;
+    }
+
+    public OntologyData withOntologyRef(java.lang.String ontologyRef) {
+        this.ontologyRef = ontologyRef;
+        return this;
+    }
+
+    @JsonProperty("term_lineage")
+    public List<String> getTermLineage() {
+        return termLineage;
+    }
+
+    @JsonProperty("term_lineage")
+    public void setTermLineage(List<String> termLineage) {
+        this.termLineage = termLineage;
+    }
+
+    public OntologyData withTermLineage(List<String> termLineage) {
+        this.termLineage = termLineage;
+        return this;
+    }
+
+    @JsonProperty("term_name")
+    public java.lang.String getTermName() {
+        return termName;
+    }
+
+    @JsonProperty("term_name")
+    public void setTermName(java.lang.String termName) {
+        this.termName = termName;
+    }
+
+    public OntologyData withTermName(java.lang.String termName) {
+        this.termName = termName;
+        return this;
+    }
+
+    @JsonProperty("evidence")
+    public List<OntologyEvidence> getEvidence() {
+        return evidence;
+    }
+
+    @JsonProperty("evidence")
+    public void setEvidence(List<OntologyEvidence> evidence) {
+        this.evidence = evidence;
+    }
+
+    public OntologyData withEvidence(List<OntologyEvidence> evidence) {
+        this.evidence = evidence;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((((((((("OntologyData"+" [id=")+ id)+", ontologyRef=")+ ontologyRef)+", termLineage=")+ termLineage)+", termName=")+ termName)+", evidence=")+ evidence)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/kbasegenomes/OntologyEvidence.java
+++ b/lib/src/us/kbase/kbasegenomes/OntologyEvidence.java
@@ -1,0 +1,137 @@
+
+package us.kbase.kbasegenomes;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import us.kbase.common.service.Tuple3;
+import us.kbase.common.service.Tuple4;
+
+
+/**
+ * <p>Original spec-file type: OntologyEvidence</p>
+ * <pre>
+ * @optional translation_provenance alignment_evidence
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "method",
+    "method_version",
+    "timestamp",
+    "translation_provenance",
+    "alignment_evidence"
+})
+public class OntologyEvidence {
+
+    @JsonProperty("method")
+    private java.lang.String method;
+    @JsonProperty("method_version")
+    private java.lang.String methodVersion;
+    @JsonProperty("timestamp")
+    private java.lang.String timestamp;
+    @JsonProperty("translation_provenance")
+    private Tuple3 <String, String, String> translationProvenance;
+    @JsonProperty("alignment_evidence")
+    private List<Tuple4 <Long, Long, Long, Double>> alignmentEvidence;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("method")
+    public java.lang.String getMethod() {
+        return method;
+    }
+
+    @JsonProperty("method")
+    public void setMethod(java.lang.String method) {
+        this.method = method;
+    }
+
+    public OntologyEvidence withMethod(java.lang.String method) {
+        this.method = method;
+        return this;
+    }
+
+    @JsonProperty("method_version")
+    public java.lang.String getMethodVersion() {
+        return methodVersion;
+    }
+
+    @JsonProperty("method_version")
+    public void setMethodVersion(java.lang.String methodVersion) {
+        this.methodVersion = methodVersion;
+    }
+
+    public OntologyEvidence withMethodVersion(java.lang.String methodVersion) {
+        this.methodVersion = methodVersion;
+        return this;
+    }
+
+    @JsonProperty("timestamp")
+    public java.lang.String getTimestamp() {
+        return timestamp;
+    }
+
+    @JsonProperty("timestamp")
+    public void setTimestamp(java.lang.String timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    public OntologyEvidence withTimestamp(java.lang.String timestamp) {
+        this.timestamp = timestamp;
+        return this;
+    }
+
+    @JsonProperty("translation_provenance")
+    public Tuple3 <String, String, String> getTranslationProvenance() {
+        return translationProvenance;
+    }
+
+    @JsonProperty("translation_provenance")
+    public void setTranslationProvenance(Tuple3 <String, String, String> translationProvenance) {
+        this.translationProvenance = translationProvenance;
+    }
+
+    public OntologyEvidence withTranslationProvenance(Tuple3 <String, String, String> translationProvenance) {
+        this.translationProvenance = translationProvenance;
+        return this;
+    }
+
+    @JsonProperty("alignment_evidence")
+    public List<Tuple4 <Long, Long, Long, Double>> getAlignmentEvidence() {
+        return alignmentEvidence;
+    }
+
+    @JsonProperty("alignment_evidence")
+    public void setAlignmentEvidence(List<Tuple4 <Long, Long, Long, Double>> alignmentEvidence) {
+        this.alignmentEvidence = alignmentEvidence;
+    }
+
+    public OntologyEvidence withAlignmentEvidence(List<Tuple4 <Long, Long, Long, Double>> alignmentEvidence) {
+        this.alignmentEvidence = alignmentEvidence;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((((((((("OntologyEvidence"+" [method=")+ method)+", methodVersion=")+ methodVersion)+", timestamp=")+ timestamp)+", translationProvenance=")+ translationProvenance)+", alignmentEvidence=")+ alignmentEvidence)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/kbasegenomes/ProteinFamily.java
+++ b/lib/src/us/kbase/kbasegenomes/ProteinFamily.java
@@ -1,0 +1,225 @@
+
+package us.kbase.kbasegenomes;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: ProteinFamily</p>
+ * <pre>
+ * Structure for a protein family
+ *         @optional query_begin query_end subject_begin subject_end score evalue subject_description release_version
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "id",
+    "subject_db",
+    "release_version",
+    "subject_description",
+    "query_begin",
+    "query_end",
+    "subject_begin",
+    "subject_end",
+    "score",
+    "evalue"
+})
+public class ProteinFamily {
+
+    @JsonProperty("id")
+    private String id;
+    @JsonProperty("subject_db")
+    private String subjectDb;
+    @JsonProperty("release_version")
+    private String releaseVersion;
+    @JsonProperty("subject_description")
+    private String subjectDescription;
+    @JsonProperty("query_begin")
+    private Long queryBegin;
+    @JsonProperty("query_end")
+    private Long queryEnd;
+    @JsonProperty("subject_begin")
+    private Long subjectBegin;
+    @JsonProperty("subject_end")
+    private Long subjectEnd;
+    @JsonProperty("score")
+    private Double score;
+    @JsonProperty("evalue")
+    private Double evalue;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("id")
+    public String getId() {
+        return id;
+    }
+
+    @JsonProperty("id")
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public ProteinFamily withId(String id) {
+        this.id = id;
+        return this;
+    }
+
+    @JsonProperty("subject_db")
+    public String getSubjectDb() {
+        return subjectDb;
+    }
+
+    @JsonProperty("subject_db")
+    public void setSubjectDb(String subjectDb) {
+        this.subjectDb = subjectDb;
+    }
+
+    public ProteinFamily withSubjectDb(String subjectDb) {
+        this.subjectDb = subjectDb;
+        return this;
+    }
+
+    @JsonProperty("release_version")
+    public String getReleaseVersion() {
+        return releaseVersion;
+    }
+
+    @JsonProperty("release_version")
+    public void setReleaseVersion(String releaseVersion) {
+        this.releaseVersion = releaseVersion;
+    }
+
+    public ProteinFamily withReleaseVersion(String releaseVersion) {
+        this.releaseVersion = releaseVersion;
+        return this;
+    }
+
+    @JsonProperty("subject_description")
+    public String getSubjectDescription() {
+        return subjectDescription;
+    }
+
+    @JsonProperty("subject_description")
+    public void setSubjectDescription(String subjectDescription) {
+        this.subjectDescription = subjectDescription;
+    }
+
+    public ProteinFamily withSubjectDescription(String subjectDescription) {
+        this.subjectDescription = subjectDescription;
+        return this;
+    }
+
+    @JsonProperty("query_begin")
+    public Long getQueryBegin() {
+        return queryBegin;
+    }
+
+    @JsonProperty("query_begin")
+    public void setQueryBegin(Long queryBegin) {
+        this.queryBegin = queryBegin;
+    }
+
+    public ProteinFamily withQueryBegin(Long queryBegin) {
+        this.queryBegin = queryBegin;
+        return this;
+    }
+
+    @JsonProperty("query_end")
+    public Long getQueryEnd() {
+        return queryEnd;
+    }
+
+    @JsonProperty("query_end")
+    public void setQueryEnd(Long queryEnd) {
+        this.queryEnd = queryEnd;
+    }
+
+    public ProteinFamily withQueryEnd(Long queryEnd) {
+        this.queryEnd = queryEnd;
+        return this;
+    }
+
+    @JsonProperty("subject_begin")
+    public Long getSubjectBegin() {
+        return subjectBegin;
+    }
+
+    @JsonProperty("subject_begin")
+    public void setSubjectBegin(Long subjectBegin) {
+        this.subjectBegin = subjectBegin;
+    }
+
+    public ProteinFamily withSubjectBegin(Long subjectBegin) {
+        this.subjectBegin = subjectBegin;
+        return this;
+    }
+
+    @JsonProperty("subject_end")
+    public Long getSubjectEnd() {
+        return subjectEnd;
+    }
+
+    @JsonProperty("subject_end")
+    public void setSubjectEnd(Long subjectEnd) {
+        this.subjectEnd = subjectEnd;
+    }
+
+    public ProteinFamily withSubjectEnd(Long subjectEnd) {
+        this.subjectEnd = subjectEnd;
+        return this;
+    }
+
+    @JsonProperty("score")
+    public Double getScore() {
+        return score;
+    }
+
+    @JsonProperty("score")
+    public void setScore(Double score) {
+        this.score = score;
+    }
+
+    public ProteinFamily withScore(Double score) {
+        this.score = score;
+        return this;
+    }
+
+    @JsonProperty("evalue")
+    public Double getEvalue() {
+        return evalue;
+    }
+
+    @JsonProperty("evalue")
+    public void setEvalue(Double evalue) {
+        this.evalue = evalue;
+    }
+
+    public ProteinFamily withEvalue(Double evalue) {
+        this.evalue = evalue;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((((((((((((((((("ProteinFamily"+" [id=")+ id)+", subjectDb=")+ subjectDb)+", releaseVersion=")+ releaseVersion)+", subjectDescription=")+ subjectDescription)+", queryBegin=")+ queryBegin)+", queryEnd=")+ queryEnd)+", subjectBegin=")+ subjectBegin)+", subjectEnd=")+ subjectEnd)+", score=")+ score)+", evalue=")+ evalue)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/workspace/ExternalDataUnit.java
+++ b/lib/src/us/kbase/workspace/ExternalDataUnit.java
@@ -1,0 +1,203 @@
+
+package us.kbase.workspace;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: ExternalDataUnit</p>
+ * <pre>
+ * An external data unit. A piece of data from a source outside the
+ * Workspace.
+ * On input, only one of the resource_release_date or
+ * resource_release_epoch may be supplied. Both are supplied on output.
+ * string resource_name - the name of the resource, for example JGI.
+ * string resource_url - the url of the resource, for example
+ *     http://genome.jgi.doe.gov
+ * string resource_version - version of the resource
+ * timestamp resource_release_date - the release date of the resource
+ * epoch resource_release_epoch - the release date of the resource
+ * string data_url - the url of the data, for example
+ *     http://genome.jgi.doe.gov/pages/dynamicOrganismDownload.jsf?
+ *         organism=BlaspURHD0036
+ * string data_id - the id of the data, for example
+ *     7625.2.79179.AGTTCC.adnq.fastq.gz
+ * string description - a free text description of the data.
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "resource_name",
+    "resource_url",
+    "resource_version",
+    "resource_release_date",
+    "resource_release_epoch",
+    "data_url",
+    "data_id",
+    "description"
+})
+public class ExternalDataUnit {
+
+    @JsonProperty("resource_name")
+    private String resourceName;
+    @JsonProperty("resource_url")
+    private String resourceUrl;
+    @JsonProperty("resource_version")
+    private String resourceVersion;
+    @JsonProperty("resource_release_date")
+    private String resourceReleaseDate;
+    @JsonProperty("resource_release_epoch")
+    private Long resourceReleaseEpoch;
+    @JsonProperty("data_url")
+    private String dataUrl;
+    @JsonProperty("data_id")
+    private String dataId;
+    @JsonProperty("description")
+    private String description;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("resource_name")
+    public String getResourceName() {
+        return resourceName;
+    }
+
+    @JsonProperty("resource_name")
+    public void setResourceName(String resourceName) {
+        this.resourceName = resourceName;
+    }
+
+    public ExternalDataUnit withResourceName(String resourceName) {
+        this.resourceName = resourceName;
+        return this;
+    }
+
+    @JsonProperty("resource_url")
+    public String getResourceUrl() {
+        return resourceUrl;
+    }
+
+    @JsonProperty("resource_url")
+    public void setResourceUrl(String resourceUrl) {
+        this.resourceUrl = resourceUrl;
+    }
+
+    public ExternalDataUnit withResourceUrl(String resourceUrl) {
+        this.resourceUrl = resourceUrl;
+        return this;
+    }
+
+    @JsonProperty("resource_version")
+    public String getResourceVersion() {
+        return resourceVersion;
+    }
+
+    @JsonProperty("resource_version")
+    public void setResourceVersion(String resourceVersion) {
+        this.resourceVersion = resourceVersion;
+    }
+
+    public ExternalDataUnit withResourceVersion(String resourceVersion) {
+        this.resourceVersion = resourceVersion;
+        return this;
+    }
+
+    @JsonProperty("resource_release_date")
+    public String getResourceReleaseDate() {
+        return resourceReleaseDate;
+    }
+
+    @JsonProperty("resource_release_date")
+    public void setResourceReleaseDate(String resourceReleaseDate) {
+        this.resourceReleaseDate = resourceReleaseDate;
+    }
+
+    public ExternalDataUnit withResourceReleaseDate(String resourceReleaseDate) {
+        this.resourceReleaseDate = resourceReleaseDate;
+        return this;
+    }
+
+    @JsonProperty("resource_release_epoch")
+    public Long getResourceReleaseEpoch() {
+        return resourceReleaseEpoch;
+    }
+
+    @JsonProperty("resource_release_epoch")
+    public void setResourceReleaseEpoch(Long resourceReleaseEpoch) {
+        this.resourceReleaseEpoch = resourceReleaseEpoch;
+    }
+
+    public ExternalDataUnit withResourceReleaseEpoch(Long resourceReleaseEpoch) {
+        this.resourceReleaseEpoch = resourceReleaseEpoch;
+        return this;
+    }
+
+    @JsonProperty("data_url")
+    public String getDataUrl() {
+        return dataUrl;
+    }
+
+    @JsonProperty("data_url")
+    public void setDataUrl(String dataUrl) {
+        this.dataUrl = dataUrl;
+    }
+
+    public ExternalDataUnit withDataUrl(String dataUrl) {
+        this.dataUrl = dataUrl;
+        return this;
+    }
+
+    @JsonProperty("data_id")
+    public String getDataId() {
+        return dataId;
+    }
+
+    @JsonProperty("data_id")
+    public void setDataId(String dataId) {
+        this.dataId = dataId;
+    }
+
+    public ExternalDataUnit withDataId(String dataId) {
+        this.dataId = dataId;
+        return this;
+    }
+
+    @JsonProperty("description")
+    public String getDescription() {
+        return description;
+    }
+
+    @JsonProperty("description")
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public ExternalDataUnit withDescription(String description) {
+        this.description = description;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((((((((((((("ExternalDataUnit"+" [resourceName=")+ resourceName)+", resourceUrl=")+ resourceUrl)+", resourceVersion=")+ resourceVersion)+", resourceReleaseDate=")+ resourceReleaseDate)+", resourceReleaseEpoch=")+ resourceReleaseEpoch)+", dataUrl=")+ dataUrl)+", dataId=")+ dataId)+", description=")+ description)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/workspace/ProvenanceAction.java
+++ b/lib/src/us/kbase/workspace/ProvenanceAction.java
@@ -1,0 +1,428 @@
+
+package us.kbase.workspace;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import us.kbase.common.service.UObject;
+
+
+/**
+ * <p>Original spec-file type: ProvenanceAction</p>
+ * <pre>
+ * A provenance action.
+ *     A provenance action (PA) is an action taken while transforming one data
+ *     object to another. There may be several PAs taken in series. A PA is
+ *     typically running a script, running an api command, etc. All of the
+ *     following fields are optional, but more information provided equates to
+ *     better data provenance.
+ *     
+ *     resolved_ws_objects should never be set by the user; it is set by the
+ *     workspace service when returning data.
+ *     
+ *     On input, only one of the time or epoch may be supplied. Both are
+ *     supplied on output.
+ *     
+ *     The maximum size of the entire provenance object, including all actions,
+ *     is 1MB.
+ *     
+ *     timestamp time - the time the action was started
+ *     epoch epoch - the time the action was started.
+ *     string caller - the name or id of the invoker of this provenance
+ *         action. In most cases, this will be the same for all PAs.
+ *     string service - the name of the service that performed this action.
+ *     string service_ver - the version of the service that performed this action.
+ *     string method - the method of the service that performed this action.
+ *     list<UnspecifiedObject> method_params - the parameters of the method
+ *         that performed this action. If an object in the parameters is a
+ *         workspace object, also put the object reference in the
+ *         input_ws_object list.
+ *     string script - the name of the script that performed this action.
+ *     string script_ver - the version of the script that performed this action.
+ *     string script_command_line - the command line provided to the script
+ *         that performed this action. If workspace objects were provided in
+ *         the command line, also put the object reference in the
+ *         input_ws_object list.
+ *     list<obj_ref> input_ws_objects - the workspace objects that
+ *         were used as input to this action; typically these will also be
+ *         present as parts of the method_params or the script_command_line
+ *         arguments.
+ *     list<obj_ref> resolved_ws_objects - the workspace objects ids from 
+ *         input_ws_objects resolved to permanent workspace object references
+ *         by the workspace service.
+ *     list<string> intermediate_incoming - if the previous action produced 
+ *         output that 1) was not stored in a referrable way, and 2) is
+ *         used as input for this action, provide it with an arbitrary and
+ *         unique ID here, in the order of the input arguments to this action.
+ *         These IDs can be used in the method_params argument.
+ *     list<string> intermediate_outgoing - if this action produced output
+ *         that 1) was not stored in a referrable way, and 2) is
+ *         used as input for the next action, provide it with an arbitrary and
+ *         unique ID here, in the order of the output values from this action.
+ *         These IDs can be used in the intermediate_incoming argument in the
+ *         next action.
+ *     list<ExternalDataUnit> external_data - data external to the workspace
+ *         that was either imported to the workspace or used to create a
+ *         workspace object.
+ *     list<SubAction> subactions - the subactions taken as a part of this
+ *         action.
+ *     mapping<string, string> custom - user definable custom provenance
+ *         fields and their values.
+ *     string description - a free text description of this action.
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "time",
+    "epoch",
+    "caller",
+    "service",
+    "service_ver",
+    "method",
+    "method_params",
+    "script",
+    "script_ver",
+    "script_command_line",
+    "input_ws_objects",
+    "resolved_ws_objects",
+    "intermediate_incoming",
+    "intermediate_outgoing",
+    "external_data",
+    "subactions",
+    "custom",
+    "description"
+})
+public class ProvenanceAction {
+
+    @JsonProperty("time")
+    private java.lang.String time;
+    @JsonProperty("epoch")
+    private Long epoch;
+    @JsonProperty("caller")
+    private java.lang.String caller;
+    @JsonProperty("service")
+    private java.lang.String service;
+    @JsonProperty("service_ver")
+    private java.lang.String serviceVer;
+    @JsonProperty("method")
+    private java.lang.String method;
+    @JsonProperty("method_params")
+    private List<UObject> methodParams;
+    @JsonProperty("script")
+    private java.lang.String script;
+    @JsonProperty("script_ver")
+    private java.lang.String scriptVer;
+    @JsonProperty("script_command_line")
+    private java.lang.String scriptCommandLine;
+    @JsonProperty("input_ws_objects")
+    private List<String> inputWsObjects;
+    @JsonProperty("resolved_ws_objects")
+    private List<String> resolvedWsObjects;
+    @JsonProperty("intermediate_incoming")
+    private List<String> intermediateIncoming;
+    @JsonProperty("intermediate_outgoing")
+    private List<String> intermediateOutgoing;
+    @JsonProperty("external_data")
+    private List<ExternalDataUnit> externalData;
+    @JsonProperty("subactions")
+    private List<SubAction> subactions;
+    @JsonProperty("custom")
+    private Map<String, String> custom;
+    @JsonProperty("description")
+    private java.lang.String description;
+    private Map<java.lang.String, Object> additionalProperties = new HashMap<java.lang.String, Object>();
+
+    @JsonProperty("time")
+    public java.lang.String getTime() {
+        return time;
+    }
+
+    @JsonProperty("time")
+    public void setTime(java.lang.String time) {
+        this.time = time;
+    }
+
+    public ProvenanceAction withTime(java.lang.String time) {
+        this.time = time;
+        return this;
+    }
+
+    @JsonProperty("epoch")
+    public Long getEpoch() {
+        return epoch;
+    }
+
+    @JsonProperty("epoch")
+    public void setEpoch(Long epoch) {
+        this.epoch = epoch;
+    }
+
+    public ProvenanceAction withEpoch(Long epoch) {
+        this.epoch = epoch;
+        return this;
+    }
+
+    @JsonProperty("caller")
+    public java.lang.String getCaller() {
+        return caller;
+    }
+
+    @JsonProperty("caller")
+    public void setCaller(java.lang.String caller) {
+        this.caller = caller;
+    }
+
+    public ProvenanceAction withCaller(java.lang.String caller) {
+        this.caller = caller;
+        return this;
+    }
+
+    @JsonProperty("service")
+    public java.lang.String getService() {
+        return service;
+    }
+
+    @JsonProperty("service")
+    public void setService(java.lang.String service) {
+        this.service = service;
+    }
+
+    public ProvenanceAction withService(java.lang.String service) {
+        this.service = service;
+        return this;
+    }
+
+    @JsonProperty("service_ver")
+    public java.lang.String getServiceVer() {
+        return serviceVer;
+    }
+
+    @JsonProperty("service_ver")
+    public void setServiceVer(java.lang.String serviceVer) {
+        this.serviceVer = serviceVer;
+    }
+
+    public ProvenanceAction withServiceVer(java.lang.String serviceVer) {
+        this.serviceVer = serviceVer;
+        return this;
+    }
+
+    @JsonProperty("method")
+    public java.lang.String getMethod() {
+        return method;
+    }
+
+    @JsonProperty("method")
+    public void setMethod(java.lang.String method) {
+        this.method = method;
+    }
+
+    public ProvenanceAction withMethod(java.lang.String method) {
+        this.method = method;
+        return this;
+    }
+
+    @JsonProperty("method_params")
+    public List<UObject> getMethodParams() {
+        return methodParams;
+    }
+
+    @JsonProperty("method_params")
+    public void setMethodParams(List<UObject> methodParams) {
+        this.methodParams = methodParams;
+    }
+
+    public ProvenanceAction withMethodParams(List<UObject> methodParams) {
+        this.methodParams = methodParams;
+        return this;
+    }
+
+    @JsonProperty("script")
+    public java.lang.String getScript() {
+        return script;
+    }
+
+    @JsonProperty("script")
+    public void setScript(java.lang.String script) {
+        this.script = script;
+    }
+
+    public ProvenanceAction withScript(java.lang.String script) {
+        this.script = script;
+        return this;
+    }
+
+    @JsonProperty("script_ver")
+    public java.lang.String getScriptVer() {
+        return scriptVer;
+    }
+
+    @JsonProperty("script_ver")
+    public void setScriptVer(java.lang.String scriptVer) {
+        this.scriptVer = scriptVer;
+    }
+
+    public ProvenanceAction withScriptVer(java.lang.String scriptVer) {
+        this.scriptVer = scriptVer;
+        return this;
+    }
+
+    @JsonProperty("script_command_line")
+    public java.lang.String getScriptCommandLine() {
+        return scriptCommandLine;
+    }
+
+    @JsonProperty("script_command_line")
+    public void setScriptCommandLine(java.lang.String scriptCommandLine) {
+        this.scriptCommandLine = scriptCommandLine;
+    }
+
+    public ProvenanceAction withScriptCommandLine(java.lang.String scriptCommandLine) {
+        this.scriptCommandLine = scriptCommandLine;
+        return this;
+    }
+
+    @JsonProperty("input_ws_objects")
+    public List<String> getInputWsObjects() {
+        return inputWsObjects;
+    }
+
+    @JsonProperty("input_ws_objects")
+    public void setInputWsObjects(List<String> inputWsObjects) {
+        this.inputWsObjects = inputWsObjects;
+    }
+
+    public ProvenanceAction withInputWsObjects(List<String> inputWsObjects) {
+        this.inputWsObjects = inputWsObjects;
+        return this;
+    }
+
+    @JsonProperty("resolved_ws_objects")
+    public List<String> getResolvedWsObjects() {
+        return resolvedWsObjects;
+    }
+
+    @JsonProperty("resolved_ws_objects")
+    public void setResolvedWsObjects(List<String> resolvedWsObjects) {
+        this.resolvedWsObjects = resolvedWsObjects;
+    }
+
+    public ProvenanceAction withResolvedWsObjects(List<String> resolvedWsObjects) {
+        this.resolvedWsObjects = resolvedWsObjects;
+        return this;
+    }
+
+    @JsonProperty("intermediate_incoming")
+    public List<String> getIntermediateIncoming() {
+        return intermediateIncoming;
+    }
+
+    @JsonProperty("intermediate_incoming")
+    public void setIntermediateIncoming(List<String> intermediateIncoming) {
+        this.intermediateIncoming = intermediateIncoming;
+    }
+
+    public ProvenanceAction withIntermediateIncoming(List<String> intermediateIncoming) {
+        this.intermediateIncoming = intermediateIncoming;
+        return this;
+    }
+
+    @JsonProperty("intermediate_outgoing")
+    public List<String> getIntermediateOutgoing() {
+        return intermediateOutgoing;
+    }
+
+    @JsonProperty("intermediate_outgoing")
+    public void setIntermediateOutgoing(List<String> intermediateOutgoing) {
+        this.intermediateOutgoing = intermediateOutgoing;
+    }
+
+    public ProvenanceAction withIntermediateOutgoing(List<String> intermediateOutgoing) {
+        this.intermediateOutgoing = intermediateOutgoing;
+        return this;
+    }
+
+    @JsonProperty("external_data")
+    public List<ExternalDataUnit> getExternalData() {
+        return externalData;
+    }
+
+    @JsonProperty("external_data")
+    public void setExternalData(List<ExternalDataUnit> externalData) {
+        this.externalData = externalData;
+    }
+
+    public ProvenanceAction withExternalData(List<ExternalDataUnit> externalData) {
+        this.externalData = externalData;
+        return this;
+    }
+
+    @JsonProperty("subactions")
+    public List<SubAction> getSubactions() {
+        return subactions;
+    }
+
+    @JsonProperty("subactions")
+    public void setSubactions(List<SubAction> subactions) {
+        this.subactions = subactions;
+    }
+
+    public ProvenanceAction withSubactions(List<SubAction> subactions) {
+        this.subactions = subactions;
+        return this;
+    }
+
+    @JsonProperty("custom")
+    public Map<String, String> getCustom() {
+        return custom;
+    }
+
+    @JsonProperty("custom")
+    public void setCustom(Map<String, String> custom) {
+        this.custom = custom;
+    }
+
+    public ProvenanceAction withCustom(Map<String, String> custom) {
+        this.custom = custom;
+        return this;
+    }
+
+    @JsonProperty("description")
+    public java.lang.String getDescription() {
+        return description;
+    }
+
+    @JsonProperty("description")
+    public void setDescription(java.lang.String description) {
+        this.description = description;
+    }
+
+    public ProvenanceAction withDescription(java.lang.String description) {
+        this.description = description;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<java.lang.String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(java.lang.String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public java.lang.String toString() {
+        return ((((((((((((((((((((((((((((((((((((((("ProvenanceAction"+" [time=")+ time)+", epoch=")+ epoch)+", caller=")+ caller)+", service=")+ service)+", serviceVer=")+ serviceVer)+", method=")+ method)+", methodParams=")+ methodParams)+", script=")+ script)+", scriptVer=")+ scriptVer)+", scriptCommandLine=")+ scriptCommandLine)+", inputWsObjects=")+ inputWsObjects)+", resolvedWsObjects=")+ resolvedWsObjects)+", intermediateIncoming=")+ intermediateIncoming)+", intermediateOutgoing=")+ intermediateOutgoing)+", externalData=")+ externalData)+", subactions=")+ subactions)+", custom=")+ custom)+", description=")+ description)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/lib/src/us/kbase/workspace/SubAction.java
+++ b/lib/src/us/kbase/workspace/SubAction.java
@@ -1,0 +1,154 @@
+
+package us.kbase.workspace;
+
+import java.util.HashMap;
+import java.util.Map;
+import javax.annotation.Generated;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
+import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+
+
+/**
+ * <p>Original spec-file type: SubAction</p>
+ * <pre>
+ * Information about a subaction that is invoked by a provenance action.
+ *     A provenance action (PA) may invoke subactions (SA), e.g. calling a
+ *     separate piece of code, a service, or a script. In most cases these
+ *     calls are the same from PA to PA and so do not need to be listed in
+ *     the provenance since providing information about the PA alone provides
+ *     reproducibility.
+ *     
+ *     In some cases, however, SAs may change over time, such that invoking
+ *     the same PA with the same parameters may produce different results.
+ *     For example, if a PA calls a remote server, that server may be updated
+ *     between a PA invoked on day T and another PA invoked on day T+1.
+ *     
+ *     The SubAction structure allows for specifying information about SAs
+ *     that may dynamically change from PA invocation to PA invocation.
+ *     
+ *     string name - the name of the SA.
+ *     string ver - the version of SA.
+ *     string code_url - a url pointing to the SA's codebase.
+ *     string commit - a version control commit ID for the SA.
+ *     string endpoint_url - a url pointing to the access point for the SA -
+ *         a server url, for instance.
+ * </pre>
+ * 
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+@Generated("com.googlecode.jsonschema2pojo")
+@JsonPropertyOrder({
+    "name",
+    "ver",
+    "code_url",
+    "commit",
+    "endpoint_url"
+})
+public class SubAction {
+
+    @JsonProperty("name")
+    private String name;
+    @JsonProperty("ver")
+    private String ver;
+    @JsonProperty("code_url")
+    private String codeUrl;
+    @JsonProperty("commit")
+    private String commit;
+    @JsonProperty("endpoint_url")
+    private String endpointUrl;
+    private Map<String, Object> additionalProperties = new HashMap<String, Object>();
+
+    @JsonProperty("name")
+    public String getName() {
+        return name;
+    }
+
+    @JsonProperty("name")
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public SubAction withName(String name) {
+        this.name = name;
+        return this;
+    }
+
+    @JsonProperty("ver")
+    public String getVer() {
+        return ver;
+    }
+
+    @JsonProperty("ver")
+    public void setVer(String ver) {
+        this.ver = ver;
+    }
+
+    public SubAction withVer(String ver) {
+        this.ver = ver;
+        return this;
+    }
+
+    @JsonProperty("code_url")
+    public String getCodeUrl() {
+        return codeUrl;
+    }
+
+    @JsonProperty("code_url")
+    public void setCodeUrl(String codeUrl) {
+        this.codeUrl = codeUrl;
+    }
+
+    public SubAction withCodeUrl(String codeUrl) {
+        this.codeUrl = codeUrl;
+        return this;
+    }
+
+    @JsonProperty("commit")
+    public String getCommit() {
+        return commit;
+    }
+
+    @JsonProperty("commit")
+    public void setCommit(String commit) {
+        this.commit = commit;
+    }
+
+    public SubAction withCommit(String commit) {
+        this.commit = commit;
+        return this;
+    }
+
+    @JsonProperty("endpoint_url")
+    public String getEndpointUrl() {
+        return endpointUrl;
+    }
+
+    @JsonProperty("endpoint_url")
+    public void setEndpointUrl(String endpointUrl) {
+        this.endpointUrl = endpointUrl;
+    }
+
+    public SubAction withEndpointUrl(String endpointUrl) {
+        this.endpointUrl = endpointUrl;
+        return this;
+    }
+
+    @JsonAnyGetter
+    public Map<String, Object> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    @JsonAnySetter
+    public void setAdditionalProperties(String name, Object value) {
+        this.additionalProperties.put(name, value);
+    }
+
+    @Override
+    public String toString() {
+        return ((((((((((((("SubAction"+" [name=")+ name)+", ver=")+ ver)+", codeUrl=")+ codeUrl)+", commit=")+ commit)+", endpointUrl=")+ endpointUrl)+", additionalProperties=")+ additionalProperties)+"]");
+    }
+
+}

--- a/test/legacy_method_test.py
+++ b/test/legacy_method_test.py
@@ -1,0 +1,214 @@
+# standard libraries
+import ConfigParser
+import functools
+import logging
+import os
+import sys
+import time
+import unittest
+
+import json
+
+from pprint import pprint
+
+# local imports
+from biokbase.workspace.client import Workspace
+from GenomeAnnotationAPI.GenomeAnnotationAPIImpl import GenomeAnnotationAPI
+from GenomeAnnotationAPI.GenomeAnnotationAPIServer import MethodContext
+
+unittest.installHandler()
+
+logging.basicConfig()
+g_logger = logging.getLogger(__file__)
+g_logger.propagate = False
+log_handler = logging.StreamHandler(sys.stdout)
+log_handler.setFormatter(logging.Formatter("%(asctime)s [%(levelname)s] %(message)s"))
+g_logger.addHandler(log_handler)
+g_logger.setLevel(logging.INFO)
+
+def log(func):
+    if not g_logger:
+        raise Exception("Missing logger for @log")
+
+    ENTRY_MSG = "Entering {} with inputs {} {}"
+    EXIT_MSG = "Exiting {}"
+
+    @functools.wraps(func)
+    def wrapper(*args, **kwargs):
+        g_logger.info(ENTRY_MSG.format(func.__name__, args, kwargs))
+        result = func(*args, **kwargs)
+        g_logger.info(EXIT_MSG.format(func.__name__))
+        return result
+
+    return wrapper
+
+
+class GenomeAnnotationAPITests(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        token = os.environ.get('KB_AUTH_TOKEN', None)
+        # WARNING: don't call any logging methods on the context object,
+        # it'll result in a NoneType error
+        cls.ctx = MethodContext(None)
+        cls.ctx.update({'token': token,
+                        'provenance': [
+                            {'service': 'GenomeAnnotationAPI',
+                             'method': 'please_never_use_it_in_production',
+                             'method_params': []
+                             }],
+                        'authenticated': 1})
+
+        config_file = os.environ.get('KB_DEPLOYMENT_CONFIG', None)
+        config = ConfigParser.ConfigParser()
+        config.read(config_file)
+        cls.cfg = {n[0]: n[1] for n in config.items('GenomeAnnotationAPI')}
+        cls.ws = Workspace(cls.cfg['workspace-url'], token=token)
+        cls.impl = GenomeAnnotationAPI(cls.cfg)
+
+
+    @classmethod
+    def tearDownClass(cls):
+        if hasattr(cls, 'wsName'):
+            cls.ws.delete_workspace({'workspace': cls.wsName})
+            print('Test workspace was deleted')
+
+    def generatePesudoRandomWorkspaceName(self):
+        if hasattr(self, 'wsName'):
+            return self.wsName
+        suffix = int(time.time() * 1000)
+        wsName = "test_GenomeAnnotationAPI_" + str(suffix)
+        ret = self.ws.create_workspace({'workspace': wsName})
+        self.wsName = wsName
+        return wsName
+
+    def getRhodobacterRef(self):
+        if hasattr(self, 'rhodobacter_ref'):
+            return self.rhodobacter_ref
+
+        # create a WS
+        wsName = self.generatePesudoRandomWorkspaceName()
+        # read in the test Rhodobacter genome
+        with open ('data/rhodobacter.json', 'r') as file:
+            data_str=file.read()
+        data = json.loads(data_str)
+        # save to ws
+        result = self.ws.save_objects({
+                'workspace':wsName,
+                'objects': [{
+                    'type':'KBaseGenomes.Genome',
+                    'data':data,
+                    'name':'rhodobacter'
+                }]
+            })
+        info = result[0]
+        self.rhodobacter_ref = str(info[6]) +'/' + str(info[0]) + '/' + str(info[4])
+        print('created rhodobacter test genome: ' + self.rhodobacter_ref)
+        return self.rhodobacter_ref
+
+
+
+    def getType(self, ref=None):
+        return self.ws.get_object_info_new({"objects": [{"ref": ref}]})[0][2]
+
+    @log
+    def test_get_all(self):
+        ret = self.impl.get_legacy_genome(self.ctx, 
+            {
+                'genomes': [ {
+                    'ref' : self.getRhodobacterRef()
+                }]
+            })[0]
+        # test stuff
+        data = ret['genomes']
+        self.assertEqual(len(data),1)
+        self.assertEqual(data[0]['data']['scientific_name'],'Rhodobacter CACIA 14H1')
+
+    @log
+    def test_get_feature_id_subdata(self):
+        ret = self.impl.get_legacy_genome(self.ctx, 
+            {
+                'genomes': [ {
+                    'ref' : self.getRhodobacterRef()
+                }],
+                'included_feature_fields':['id']
+            })[0]
+        # test stuff
+        data = ret['genomes']
+        self.assertEqual(data[0]['data']['features'][0]['id'],'kb|g.220339.CDS.1')
+        self.assertEqual(len(data[0]['data']['features']),4158)
+        self.assertTrue('scientific_name' not in data[0]['data'])
+
+
+    @log
+    def test_get_feature_id_subdata(self):
+        ret = self.impl.get_legacy_genome(self.ctx, 
+            {
+                'genomes': [ {
+                    'ref' : self.getRhodobacterRef(),
+                    'included_feature_position_index':[3,8]
+                }],
+                'included_feature_fields':['id']
+            })[0]
+        # test stuff
+        data = ret['genomes']
+        self.assertEqual(data[0]['data']['features'][0]['id'],'kb|g.220339.CDS.4')
+        self.assertEqual(data[0]['data']['features'][1]['id'],'kb|g.220339.CDS.9')
+        self.assertEqual(len(data[0]['data']['features']),2)
+
+    @log
+    def test_get_feature_id_subdata_with_some_fields(self):
+        ret = self.impl.get_legacy_genome(self.ctx, 
+            {
+                'genomes': [ {
+                    'ref' : self.getRhodobacterRef(),
+                    'included_feature_position_index':[3,8]
+                }],
+                'included_feature_fields':['id','function'],
+                'included_fields':['domain','scientific_name']
+            })[0]
+        # test stuff
+        data = ret['genomes']
+        self.assertEqual(data[0]['data']['scientific_name'],'Rhodobacter CACIA 14H1')
+        self.assertEqual(data[0]['data']['domain'],'Bacteria')
+        self.assertEqual(data[0]['data']['features'][0]['function'],'FIG01142552: hypothetical protein')
+        self.assertEqual(data[0]['data']['features'][0]['id'],'kb|g.220339.CDS.4')
+
+    @log
+    def test_get_with_no_meta(self):
+        ret = self.impl.get_legacy_genome(self.ctx, 
+            {
+                'genomes': [ {
+                    'ref' : self.getRhodobacterRef(),
+                    'included_feature_position_index':[3,8]
+                }],
+                'included_feature_fields':['id','function'],
+                'included_fields':['domain','scientific_name'],
+                'no_metadata':1
+            })[0]
+        # test stuff
+        data = ret['genomes']
+        self.assertTrue('info' not in data[0])
+        self.assertTrue('provenance' not in data[0])
+
+
+    @log
+    def test_get_feature_id_subdata_everything(self):
+        ret = self.impl.get_legacy_genome(self.ctx, 
+            {
+                'genomes': [ {
+                    'ref' : self.getRhodobacterRef(),
+                    'included_feature_position_index':[3,8]
+                }],
+                'included_feature_fields':[],
+                'included_fields':['domain','scientific_name']
+            })[0]
+        # test stuff
+        data = ret['genomes']
+        self.assertEqual(data[0]['data']['scientific_name'],'Rhodobacter CACIA 14H1')
+        self.assertEqual(data[0]['data']['domain'],'Bacteria')
+        self.assertEqual(data[0]['data']['features'][0]['function'],'FIG01142552: hypothetical protein')
+        self.assertEqual(data[0]['data']['features'][0]['id'],'kb|g.220339.CDS.4')
+
+
+    

--- a/workspace.spec
+++ b/workspace.spec
@@ -1,0 +1,1940 @@
+/*
+ - copied from:
+    https://github.com/kbase/workspace_deluxe/blob/develop/workspace.spec
+    837ad4c4c5037f99e44094d23bd92ac2c956a88e
+
+
+The Workspace Service (WSS) is primarily a language independent remote storage
+and retrieval system for KBase typed objects (TO) defined with the KBase
+Interface Description Language (KIDL). It has the following primary features:
+- Immutable storage of TOs with
+    - user defined metadata 
+    - data provenance
+- Versioning of TOs
+- Referencing from TO to TO
+- Typechecking of all saved objects against a KIDL specification
+- Collecting typed objects into a workspace
+- Sharing workspaces with specific KBase users or the world
+- Freezing and publishing workspaces
+
+*/
+module Workspace {
+    
+    /* A boolean. 0 = false, other = true. */
+    typedef int boolean;
+    
+    /* The unique, permanent numerical ID of a workspace. */
+    typedef int ws_id;
+    
+    /* A string used as a name for a workspace.
+        Any string consisting of alphanumeric characters and "_", ".", or "-"
+        that is not an integer is acceptable. The name may optionally be
+        prefixed with the workspace owner's user name and a colon, e.g.
+        kbasetest:my_workspace.
+    */
+    typedef string ws_name;
+    
+    /* Represents the permissions a user or users have to a workspace:
+    
+        'a' - administrator. All operations allowed.
+        'w' - read/write.
+        'r' - read.
+        'n' - no permissions.
+    */
+    typedef string permission;
+    
+    /* Login name of a KBase user account. */
+    typedef string username;
+    
+    /* 
+        A time in the format YYYY-MM-DDThh:mm:ssZ, where Z is either the
+        character Z (representing the UTC timezone) or the difference
+        in time to UTC in the format +/-HHMM, eg:
+            2012-12-17T23:24:06-0500 (EST time)
+            2013-04-03T08:56:32+0000 (UTC time)
+            2013-04-03T08:56:32Z (UTC time)
+    */
+    typedef string timestamp;
+    
+    /* A Unix epoch (the time since 00:00:00 1/1/1970 UTC) in milliseconds. */
+    typedef int epoch; 
+    
+    /* A type string.
+        Specifies the type and its version in a single string in the format
+        [module].[typename]-[major].[minor]:
+        
+        module - a string. The module name of the typespec containing the type.
+        typename - a string. The name of the type as assigned by the typedef
+            statement.
+        major - an integer. The major version of the type. A change in the
+            major version implies the type has changed in a non-backwards
+            compatible way.
+        minor - an integer. The minor version of the type. A change in the
+            minor version implies that the type has changed in a way that is
+            backwards compatible with previous type definitions.
+        
+        In many cases, the major and minor versions are optional, and if not
+        provided the most recent version will be used.
+        
+        Example: MyModule.MyType-3.1
+    */
+    typedef string type_string;
+    
+    /* An id type (e.g. from a typespec @id annotation: @id [idtype]) */
+    typedef string id_type;
+    
+    /* An id extracted from an object. */
+    typedef string extracted_id;
+    
+    /* User provided metadata about an object.
+        Arbitrary key-value pairs provided by the user.
+    */
+    typedef mapping<string, string> usermeta;
+    
+    /* The lock status of a workspace.
+        One of 'unlocked', 'locked', or 'published'.
+    */
+    typedef string lock_status;
+    
+    /* A workspace identifier.
+
+        Select a workspace by one, and only one, of the numerical id or name,
+            where the name can also be a KBase ID including the numerical id,
+            e.g. kb|ws.35.
+        ws_id id - the numerical ID of the workspace.
+        ws_name workspace - name of the workspace or the workspace ID in KBase
+            format, e.g. kb|ws.78.
+        
+    */
+    typedef structure {
+        ws_name workspace;
+        ws_id id;
+    } WorkspaceIdentity;
+    
+    /* Meta data associated with a workspace. Provided for backwards
+        compatibility. To be replaced by workspace_info.
+    
+        ws_name id - name of the workspace 
+        username owner - name of the user who owns (who created) this workspace
+        timestamp moddate - date when the workspace was last modified
+        int objects - the approximate number of objects currently stored in
+            the workspace.
+        permission user_permission - permissions for the currently logged in
+            user for the workspace
+        permission global_permission - default permissions for the workspace
+            for all KBase users
+        ws_id num_id - numerical ID of the workspace
+        
+        @deprecated Workspace.workspace_info
+    */
+    typedef tuple<ws_name id, username owner, timestamp moddate,
+        int objects, permission user_permission, permission global_permission,
+        ws_id num_id> workspace_metadata;
+    
+    /* Information about a workspace.
+    
+        ws_id id - the numerical ID of the workspace.
+        ws_name workspace - name of the workspace.
+        username owner - name of the user who owns (e.g. created) this workspace.
+        timestamp moddate - date when the workspace was last modified.
+        int max_objid - the maximum object ID appearing in this workspace.
+            Since cloning a workspace preserves object IDs, this number may be
+            greater than the number of objects in a newly cloned workspace.
+        permission user_permission - permissions for the authenticated user of
+            this workspace.
+        permission globalread - whether this workspace is globally readable.
+        lock_status lockstat - the status of the workspace lock.
+        usermeta metadata - arbitrary user-supplied metadata about
+            the workspace.
+            
+    */
+    typedef tuple<ws_id id, ws_name workspace, username owner, timestamp moddate,
+        int max_objid, permission user_permission, permission globalread,
+        lock_status lockstat, usermeta metadata> workspace_info;
+        
+    /* The unique, permanent numerical ID of an object. */
+    typedef int obj_id;
+    
+    /* A string used as a name for an object.
+        Any string consisting of alphanumeric characters and the characters
+            |._- that is not an integer is acceptable.
+    */
+    typedef string obj_name;
+    
+    /* An object version.
+        The version of the object, starting at 1.
+    */
+    typedef int obj_ver;
+    
+    /* A string that uniquely identifies an object in the workspace service.
+    
+        There are two ways to uniquely identify an object in one string:
+        "[ws_name or id]/[obj_name or id]/[obj_ver]" - for example,
+            "MyFirstWorkspace/MyFirstObject/3" would identify the third version
+            of an object called MyFirstObject in the workspace called
+            MyFirstWorkspace. 42/Panic/1 would identify the first version of
+            the object name Panic in workspace with id 42. Towel/1/6 would
+            identify the 6th version of the object with id 1 in the Towel
+            workspace. 
+        "kb|ws.[ws_id].obj.[obj_id].ver.[obj_ver]" - for example, 
+            "kb|ws.23.obj.567.ver.2" would identify the second version of an
+            object with id 567 in a workspace with id 23.
+        In all cases, if the version number is omitted, the latest version of
+        the object is assumed.
+    */
+    typedef string obj_ref;
+    
+    /* An object identifier.
+        
+        Select an object by either:
+            One, and only one, of the numerical id or name of the workspace,
+            where the name can also be a KBase ID including the numerical id,
+            e.g. kb|ws.35.
+                ws_id wsid - the numerical ID of the workspace.
+                ws_name workspace - name of the workspace or the workspace ID
+                    in KBase format, e.g. kb|ws.78.
+            AND 
+            One, and only one, of the numerical id or name of the object.
+                obj_id objid- the numerical ID of the object.
+                obj_name name - name of the object.
+            OPTIONALLY
+                obj_ver ver - the version of the object.
+        OR an object reference string:
+            obj_ref ref - an object reference string.
+    */
+    typedef structure {
+        ws_name workspace;
+        ws_id wsid;
+        obj_name name;
+        obj_id objid;
+        obj_ver ver;
+        obj_ref ref;
+    } ObjectIdentity;
+    
+    /* A chain of objects with references to one another.
+    
+        An object reference chain consists of a list of objects where the nth
+        object possesses a reference, either in the object itself or in the
+        object provenance, to the n+1th object.
+    */
+    typedef list<ObjectIdentity> ref_chain;
+    
+    /* A path into an object. 
+        Identify a sub portion of an object by providing the path, delimited by
+        a slash (/), to that portion of the object. Thus the path may not have
+        slashes in the structure or mapping keys. Examples:
+        /foo/bar/3 - specifies the bar key of the foo mapping and the 3rd
+            entry of the array if bar maps to an array or the value mapped to
+            the string "3" if bar maps to a map.
+        /foo/bar/[*]/baz - specifies the baz field of all the objects in the
+            list mapped by the bar key in the map foo.
+        /foo/asterisk/baz - specifies the baz field of all the objects in the
+            values of the foo mapping. Swap 'asterisk' for * in the path.
+        In case you need to use '/' or '~' in path items use JSON Pointer 
+            notation defined here: http://tools.ietf.org/html/rfc6901
+    */
+    typedef string object_path;
+    
+    /*  DEPRECATED
+    
+        An object subset identifier.
+        
+        Select a subset of an object by:
+        EITHER
+            One, and only one, of the numerical id or name of the workspace,
+            where the name can also be a KBase ID including the numerical id,
+            e.g. kb|ws.35.
+                ws_id wsid - the numerical ID of the workspace.
+                ws_name workspace - name of the workspace or the workspace ID
+                    in KBase format, e.g. kb|ws.78.
+            AND 
+            One, and only one, of the numerical id or name of the object.
+                obj_id objid- the numerical ID of the object.
+                obj_name name - name of the object.
+            OPTIONALLY
+                obj_ver ver - the version of the object.
+        OR an object reference string:
+            obj_ref ref - an object reference string.
+        AND a subset specification:
+            list<object_path> included - the portions of the object to include
+                in the object subset.
+        boolean strict_maps - if true, throw an exception if the subset
+            specification traverses a non-existant map key (default false)
+        boolean strict_arrays - if true, throw an exception if the subset
+            specification exceeds the size of an array (default true)
+            
+        @deprecated Workspace.ObjectSpecification
+    */
+    typedef structure {
+        ws_name workspace;
+        ws_id wsid;
+        obj_name name;
+        obj_id objid;
+        obj_ver ver;
+        obj_ref ref;
+        list<object_path> included;
+        boolean strict_maps;
+        boolean strict_arrays;
+    } SubObjectIdentity;
+    
+    /* An Object Specification (OS). Inherits from ObjectIdentity.
+        Specifies which object, and which parts of that object, to retrieve
+        from the Workspace Service.
+        
+        The fields wsid, workspace, objid, name, ver, and ref are identical to
+        the ObjectIdentity fields.
+        
+        REFERENCE FOLLOWING:
+        
+        Reference following guarantees that a user that has access to an
+        object can always see a) objects that are referenced inside the object
+        and b) objects that are referenced in the object's provenance. This
+        ensures that the user has visibility into the entire provenance of the
+        object and the object's object dependencies (e.g. references).
+        
+        The user must have at least read access to the object specified in this
+        SO, but need not have access to any further objects in the reference
+        chain, and those objects may be deleted.
+        
+        Optional reference following fields:
+        ref_chain obj_path - a path to the desired object from the object
+            specified in this OS. In other words, the object specified in this
+            OS is assumed to be accessible to the user, and the objects in
+            the object path represent a chain of references to the desired
+            object at the end of the object path. If the references are all
+            valid, the desired object will be returned.
+        - OR -
+        list<obj_ref> obj_ref_path - shorthand for the obj_path. Only one of
+            obj_path or obj_ref_path may be specified.
+        
+        OBJECT SUBSETS:
+        
+        When selecting a subset of an array in an object, the returned
+        array is compressed to the size of the subset, but the ordering of
+        the array is maintained. For example, if the array stored at the
+        'feature' key of a Genome object has 4000 entries, and the object paths
+        provided are:
+            /feature/7
+            /feature/3015
+            /feature/700
+        The returned feature array will be of length three and the entries will
+        consist, in order, of the 7th, 700th, and 3015th entries of the
+        original array.
+        
+        Optional object subset fields:
+        list<object_path> included - the portions of the object to include
+                in the object subset.
+        boolean strict_maps - if true, throw an exception if the subset
+            specification traverses a non-existant map key (default false)
+        boolean strict_arrays - if true, throw an exception if the subset
+            specification exceeds the size of an array (default true)
+    */
+    typedef structure {
+        ws_name workspace;
+        ws_id wsid;
+        obj_name name;
+        obj_id objid;
+        obj_ver ver;
+        obj_ref ref;
+        ref_chain obj_path;
+        list<obj_ref> obj_ref_path;
+        list<object_path> included;
+        boolean strict_maps;
+        boolean strict_arrays;
+    } ObjectSpecification;
+    
+    /* Meta data associated with an object stored in a workspace. Provided for
+        backwards compatibility.
+    
+        obj_name id - name of the object.
+        type_string type - type of the object.
+        timestamp moddate - date when the object was saved
+        obj_ver instance - the version of the object
+        string command - Deprecated. Always returns the empty string.
+        username lastmodifier - name of the user who last saved the object,
+            including copying the object
+        username owner - Deprecated. Same as lastmodifier.
+        ws_name workspace - name of the workspace in which the object is
+            stored
+        string ref - Deprecated. Always returns the empty string.
+        string chsum - the md5 checksum of the object.
+        usermeta metadata - arbitrary user-supplied metadata about
+            the object.
+        obj_id objid - the numerical id of the object.
+        
+        @deprecated object_info
+    */
+    typedef tuple<obj_name id, type_string type, timestamp moddate,
+        int instance, string command, username lastmodifier, username owner,
+        ws_name workspace, string ref, string chsum, usermeta metadata,
+        obj_id objid> object_metadata;
+        
+    /* Information about an object, including user provided metadata.
+    
+        obj_id objid - the numerical id of the object.
+        obj_name name - the name of the object.
+        type_string type - the type of the object.
+        timestamp save_date - the save date of the object.
+        obj_ver ver - the version of the object.
+        username saved_by - the user that saved or copied the object.
+        ws_id wsid - the workspace containing the object.
+        ws_name workspace - the workspace containing the object.
+        string chsum - the md5 checksum of the object.
+        int size - the size of the object in bytes.
+        usermeta meta - arbitrary user-supplied metadata about
+            the object.
+
+    */
+    typedef tuple<obj_id objid, obj_name name, type_string type,
+        timestamp save_date, int version, username saved_by,
+        ws_id wsid, ws_name workspace, string chsum, int size, usermeta meta>
+        object_info;
+    
+    /* An external data unit. A piece of data from a source outside the
+        Workspace.
+        
+        On input, only one of the resource_release_date or
+        resource_release_epoch may be supplied. Both are supplied on output.
+        
+        string resource_name - the name of the resource, for example JGI.
+        string resource_url - the url of the resource, for example
+            http://genome.jgi.doe.gov
+        string resource_version - version of the resource
+        timestamp resource_release_date - the release date of the resource
+        epoch resource_release_epoch - the release date of the resource
+        string data_url - the url of the data, for example
+            http://genome.jgi.doe.gov/pages/dynamicOrganismDownload.jsf?
+                organism=BlaspURHD0036
+        string data_id - the id of the data, for example
+            7625.2.79179.AGTTCC.adnq.fastq.gz
+        string description - a free text description of the data.
+    
+    */
+    typedef structure {
+        string resource_name;
+        string resource_url;
+        string resource_version;
+        timestamp resource_release_date;
+        epoch resource_release_epoch;
+        string data_url;
+        string data_id;
+        string description;
+    } ExternalDataUnit;
+    
+    /* Information about a subaction that is invoked by a provenance action.
+    
+        A provenance action (PA) may invoke subactions (SA), e.g. calling a
+        separate piece of code, a service, or a script. In most cases these
+        calls are the same from PA to PA and so do not need to be listed in
+        the provenance since providing information about the PA alone provides
+        reproducibility.
+        
+        In some cases, however, SAs may change over time, such that invoking
+        the same PA with the same parameters may produce different results.
+        For example, if a PA calls a remote server, that server may be updated
+        between a PA invoked on day T and another PA invoked on day T+1.
+        
+        The SubAction structure allows for specifying information about SAs
+        that may dynamically change from PA invocation to PA invocation.
+        
+        string name - the name of the SA.
+        string ver - the version of SA.
+        string code_url - a url pointing to the SA's codebase.
+        string commit - a version control commit ID for the SA.
+        string endpoint_url - a url pointing to the access point for the SA -
+            a server url, for instance.
+    */
+    typedef structure {
+        string name;
+        string ver;
+        string code_url;
+        string commit;
+        string endpoint_url;
+    } SubAction;
+    
+    /* A provenance action.
+    
+        A provenance action (PA) is an action taken while transforming one data
+        object to another. There may be several PAs taken in series. A PA is
+        typically running a script, running an api command, etc. All of the
+        following fields are optional, but more information provided equates to
+        better data provenance.
+        
+        resolved_ws_objects should never be set by the user; it is set by the
+        workspace service when returning data.
+        
+        On input, only one of the time or epoch may be supplied. Both are
+        supplied on output.
+        
+        The maximum size of the entire provenance object, including all actions,
+        is 1MB.
+        
+        timestamp time - the time the action was started
+        epoch epoch - the time the action was started.
+        string caller - the name or id of the invoker of this provenance
+            action. In most cases, this will be the same for all PAs.
+        string service - the name of the service that performed this action.
+        string service_ver - the version of the service that performed this action.
+        string method - the method of the service that performed this action.
+        list<UnspecifiedObject> method_params - the parameters of the method
+            that performed this action. If an object in the parameters is a
+            workspace object, also put the object reference in the
+            input_ws_object list.
+        string script - the name of the script that performed this action.
+        string script_ver - the version of the script that performed this action.
+        string script_command_line - the command line provided to the script
+            that performed this action. If workspace objects were provided in
+            the command line, also put the object reference in the
+            input_ws_object list.
+        list<obj_ref> input_ws_objects - the workspace objects that
+            were used as input to this action; typically these will also be
+            present as parts of the method_params or the script_command_line
+            arguments.
+        list<obj_ref> resolved_ws_objects - the workspace objects ids from 
+            input_ws_objects resolved to permanent workspace object references
+            by the workspace service.
+        list<string> intermediate_incoming - if the previous action produced 
+            output that 1) was not stored in a referrable way, and 2) is
+            used as input for this action, provide it with an arbitrary and
+            unique ID here, in the order of the input arguments to this action.
+            These IDs can be used in the method_params argument.
+        list<string> intermediate_outgoing - if this action produced output
+            that 1) was not stored in a referrable way, and 2) is
+            used as input for the next action, provide it with an arbitrary and
+            unique ID here, in the order of the output values from this action.
+            These IDs can be used in the intermediate_incoming argument in the
+            next action.
+        list<ExternalDataUnit> external_data - data external to the workspace
+            that was either imported to the workspace or used to create a
+            workspace object.
+        list<SubAction> subactions - the subactions taken as a part of this
+            action.
+        mapping<string, string> custom - user definable custom provenance
+            fields and their values.
+        string description - a free text description of this action.
+    */
+    typedef structure {
+        timestamp time;
+        epoch epoch;
+        string caller;
+        string service;
+        string service_ver;
+        string method;
+        list<UnspecifiedObject> method_params;
+        string script;
+        string script_ver;
+        string script_command_line;
+        list<obj_ref> input_ws_objects;
+        list<obj_ref> resolved_ws_objects;
+        list<string> intermediate_incoming;
+        list<string> intermediate_outgoing;
+        list<ExternalDataUnit> external_data;
+        list<SubAction> subactions;
+        mapping<string, string> custom;
+        string description;
+    } ProvenanceAction;
+    
+    /*
+        Returns the version of the workspace service.
+    */
+    funcdef ver() returns(string ver) authentication none;
+
+    /* Input parameters for the "create_workspace" function.
+    
+        Required arguments:
+        ws_name workspace - name of the workspace to be created.
+        
+        Optional arguments:
+        permission globalread - 'r' to set the new workspace globally readable,
+            default 'n'.
+        string description - A free-text description of the new workspace, 1000
+            characters max. Longer strings will be mercilessly and brutally
+            truncated.
+        usermeta meta - arbitrary user-supplied metadata for the workspace.
+    */
+    typedef structure { 
+        ws_name workspace;
+        permission globalread;
+        string description;
+        usermeta meta;
+    } CreateWorkspaceParams;
+    
+    /*
+        Creates a new workspace.
+    */
+    funcdef create_workspace(CreateWorkspaceParams params) returns
+        (workspace_info info) authentication required;
+    
+    /* Input parameters for the "alter_workspace_metadata" function.
+        
+        Required arguments:
+        WorkspaceIdentity wsi - the workspace to be altered
+        
+        One or both of the following arguments are required:
+        usermeta new - metadata to assign to the workspace. Duplicate keys will
+            be overwritten.
+        list<string> remove - these keys will be removed from the workspace
+            metadata key/value pairs.
+    */
+    typedef structure {
+        WorkspaceIdentity wsi;
+        usermeta new;
+        list<string> remove;
+    } AlterWorkspaceMetadataParams;
+    
+    /*
+        Change the metadata associated with a workspace.
+    */
+    funcdef alter_workspace_metadata(AlterWorkspaceMetadataParams params)
+        returns() authentication required;
+    
+    /* Input parameters for the "clone_workspace" function.
+    
+        Note that deleted objects are not cloned, although hidden objects are
+        and remain hidden in the new workspace.
+    
+        Required arguments:
+        WorkspaceIdentity wsi - the workspace to be cloned.
+        ws_name workspace - name of the workspace to be cloned into. This must
+            be a non-existant workspace name.
+        
+        Optional arguments:
+        permission globalread - 'r' to set the new workspace globally readable,
+            default 'n'.
+        string description - A free-text description of the new workspace, 1000
+            characters max. Longer strings will be mercilessly and brutally
+            truncated.
+        usermeta meta - arbitrary user-supplied metadata for the workspace.
+        list<ObjectIdentity> exclude - exclude the specified objects from the
+            cloned workspace. Either an object ID or a object name must be
+            specified in each ObjectIdentity - any supplied reference strings,
+            workspace names or IDs, and versions are ignored. 
+    */
+    typedef structure { 
+        WorkspaceIdentity wsi;
+        ws_name workspace;
+        permission globalread;
+        string description;
+        usermeta meta;
+        list<ObjectIdentity> exclude;
+    } CloneWorkspaceParams;
+    
+    /*
+        Clones a workspace.
+    */
+    funcdef clone_workspace(CloneWorkspaceParams params) returns
+        (workspace_info info) authentication required;
+    
+    /* Lock a workspace, preventing further changes.
+    
+        WARNING: Locking a workspace is permanent. A workspace, once locked,
+        cannot be unlocked.
+        
+        The only changes allowed for a locked workspace are changing user
+        based permissions or making a private workspace globally readable,
+        thus permanently publishing the workspace. A locked, globally readable
+        workspace cannot be made private.
+    */
+    funcdef lock_workspace(WorkspaceIdentity wsi) returns(workspace_info info)
+        authentication required;
+    
+    /* Input parameters for the "get_workspacemeta" function. Provided for
+        backwards compatibility.
+    
+        One, and only one of:
+        ws_name workspace - name of the workspace or the workspace ID in KBase
+            format, e.g. kb|ws.78.
+        ws_id id - the numerical ID of the workspace.
+            
+        Optional arguments:
+        string auth - the authentication token of the KBase account accessing
+            the workspace. Overrides the client provided authorization
+            credentials if they exist.
+        
+        @deprecated Workspace.WorkspaceIdentity
+    */
+    typedef structure { 
+        ws_name workspace;
+        ws_id id;
+        string auth;
+    } get_workspacemeta_params;
+    
+    /*
+        Retrieves the metadata associated with the specified workspace.
+        Provided for backwards compatibility. 
+        @deprecated Workspace.get_workspace_info
+    */
+    funcdef get_workspacemeta(get_workspacemeta_params params) 
+        returns(workspace_metadata metadata) authentication optional;
+    
+    /*
+        Get information associated with a workspace.
+    */
+    funcdef get_workspace_info(WorkspaceIdentity wsi)
+        returns (workspace_info info) authentication optional;
+    
+    /* 
+        Get a workspace's description.
+    */
+    funcdef get_workspace_description(WorkspaceIdentity wsi)
+        returns (string description) authentication optional;
+    
+    /* Input parameters for the "set_permissions" function.
+    
+        One, and only one, of the following is required:
+        ws_id id - the numerical ID of the workspace.
+        ws_name workspace - name of the workspace or the workspace ID in KBase
+            format, e.g. kb|ws.78.
+        
+        Required arguments:
+        permission new_permission - the permission to assign to the users.
+        list<username> users - the users whose permissions will be altered.
+    */
+    typedef structure {
+        ws_name workspace;
+        ws_id id;
+        permission new_permission;
+        list<username> users;
+    } SetPermissionsParams;
+    
+    /* 
+        Set permissions for a workspace.
+    */
+    funcdef set_permissions(SetPermissionsParams params) returns()
+        authentication required;
+    
+    /* Input parameters for the "set_global_permission" function.
+    
+        One, and only one, of the following is required:
+        ws_id id - the numerical ID of the workspace.
+        ws_name workspace - name of the workspace or the workspace ID in KBase
+            format, e.g. kb|ws.78.
+        
+        Required arguments:
+        permission new_permission - the permission to assign to all users,
+            either 'n' or 'r'. 'r' means that all users will be able to read
+            the workspace; otherwise users must have specific permission to
+            access the workspace.
+    */
+    typedef structure {
+        ws_name workspace;
+        ws_id id;
+        permission new_permission;
+    } SetGlobalPermissionsParams;
+    
+    /* 
+        Set the global permission for a workspace.
+    */
+    funcdef set_global_permission(SetGlobalPermissionsParams params) returns()
+        authentication required;
+    
+    /* Input parameters for the "set_workspace_description" function.
+    
+        One, and only one, of the following is required:
+        ws_id id - the numerical ID of the workspace.
+        ws_name workspace - name of the workspace or the workspace ID in KBase
+            format, e.g. kb|ws.78.
+        
+        Optional arguments:
+        string description - A free-text description of the workspace, 1000
+            characters max. Longer strings will be mercilessly and brutally
+            truncated. If omitted, the description is set to null.
+    */
+    typedef structure {
+        ws_name workspace;
+        ws_id id;
+        string description;
+    } SetWorkspaceDescriptionParams;
+    
+    /* 
+        Set the description for a workspace.
+    */
+    funcdef set_workspace_description(SetWorkspaceDescriptionParams params)
+        returns() authentication required;
+    
+    /* Input parameters for the "get_permissions_mass" function.
+        workspaces - the workspaces for which to return the permissions,
+            maximum 1000.
+    */
+    typedef structure {
+        list<WorkspaceIdentity> workspaces;
+    } GetPermissionsMassParams;
+    
+    /* A set of workspace permissions.
+        perms - the list of permissions for each requested workspace
+    
+    */
+    typedef structure {
+        list<mapping<username, permission>> perms;
+    } WorkspacePermissions;
+    
+    /* 
+        Get permissions for multiple workspaces.
+    */
+    funcdef get_permissions_mass(GetPermissionsMassParams mass)
+        returns(WorkspacePermissions perms) authentication optional;
+    
+    /* 
+        Get permissions for a workspace.
+        @deprecated get_permissions_mass
+    */
+    funcdef get_permissions(WorkspaceIdentity wsi) returns
+        (mapping<username, permission> perms) authentication optional;
+    
+    /* Input parameters for the "save_object" function. Provided for backwards
+        compatibility.
+    
+        Required arguments:
+        type_string type - type of the object to be saved
+        ws_name workspace - name of the workspace where the object is to be
+            saved
+        obj_name id - name behind which the object will be saved in the
+            workspace
+        UnspecifiedObject data - data to be saved in the workspace
+        
+        Optional arguments:
+        usermeta metadata - arbitrary user-supplied metadata for the object,
+            not to exceed 16kb; if the object type specifies automatic
+            metadata extraction with the 'meta ws' annotation, and your
+            metadata name conflicts, then your metadata will be silently
+            overwritten.
+        string auth - the authentication token of the KBase account accessing
+            the workspace. Overrides the client provided authorization
+            credentials if they exist.
+        
+        @deprecated
+    */
+    typedef structure { 
+        obj_name id;
+        type_string type;
+        UnspecifiedObject data;
+        ws_name workspace;
+        mapping<string,string> metadata;
+        string auth;
+    } save_object_params;
+    
+    /*
+        Saves the input object data and metadata into the selected workspace,
+            returning the object_metadata of the saved object. Provided
+            for backwards compatibility.
+            
+        @deprecated Workspace.save_objects
+    */
+    funcdef save_object(save_object_params params) 
+        returns(object_metadata metadata) authentication optional;
+    
+    /* An object and associated data required for saving.
+    
+        Required arguments:
+        type_string type - the type of the object. Omit the version information
+            to use the latest version.
+        UnspecifiedObject data - the object data.
+        
+        Optional arguments:
+        One of an object name or id. If no name or id is provided the name
+            will be set to 'auto' with the object id appended as a string,
+            possibly with -\d+ appended if that object id already exists as a
+            name.
+        obj_name name - the name of the object.
+        obj_id objid - the id of the object to save over.
+        usermeta meta - arbitrary user-supplied metadata for the object,
+            not to exceed 16kb; if the object type specifies automatic
+            metadata extraction with the 'meta ws' annotation, and your
+            metadata name conflicts, then your metadata will be silently
+            overwritten.
+        list<ProvenanceAction> provenance - provenance data for the object.
+        boolean hidden - true if this object should not be listed when listing
+            workspace objects.
+    
+    */
+    typedef structure {
+        type_string type;
+        UnspecifiedObject data;
+        obj_name name;
+        obj_id objid;
+        usermeta meta;
+        list<ProvenanceAction> provenance;
+        boolean hidden;
+    } ObjectSaveData;
+    
+    /* Input parameters for the "save_objects" function.
+    
+        One, and only one, of the following is required:
+        ws_id id - the numerical ID of the workspace.
+        ws_name workspace - name of the workspace or the workspace ID in KBase
+            format, e.g. kb|ws.78.
+        
+        Required arguments:
+        list<ObjectSaveData> objects - the objects to save.
+        
+    */
+    typedef structure {
+        ws_name workspace;
+        ws_id id;
+        list<ObjectSaveData> objects;
+    } SaveObjectsParams;
+    
+    /* 
+        Save objects to the workspace. Saving over a deleted object undeletes
+        it.
+    */
+    funcdef save_objects(SaveObjectsParams params)
+        returns (list<object_info> info) authentication required;
+    
+    /* Input parameters for the "get_object" function. Provided for backwards
+        compatibility.
+    
+        Required arguments:
+        ws_name workspace - Name of the workspace containing the object to be
+            retrieved
+        obj_name id - Name of the object to be retrieved
+        
+        Optional arguments:
+        int instance - Version of the object to be retrieved, enabling
+            retrieval of any previous version of an object
+        string auth - the authentication token of the KBase account accessing
+            the object. Overrides the client provided authorization
+            credentials if they exist.
+        
+        @deprecated Workspace.ObjectIdentity    
+    */
+    typedef structure { 
+        obj_name id;
+        ws_name workspace;
+        int instance;
+        string auth;
+    } get_object_params;
+    
+    /* Output generated by the "get_object" function. Provided for backwards
+        compatibility.
+    
+        UnspecifiedObject data - The object's data.
+        object_metadata metadata - Metadata for object retrieved/
+    
+        @deprecated Workspaces.ObjectData
+    */
+    typedef structure {
+        UnspecifiedObject data;
+        object_metadata metadata;
+    } get_object_output;
+    
+    /*
+        Retrieves the specified object from the specified workspace.
+        Both the object data and metadata are returned.
+        Provided for backwards compatibility.
+        
+        @deprecated Workspace.get_objects
+    */
+    funcdef get_object(get_object_params params)
+        returns (get_object_output output) authentication optional;
+    
+    /*  DEPRECATED
+    
+        The provenance and supplemental info for an object.
+    
+        object_info info - information about the object.
+        list<ProvenanceAction> provenance - the object's provenance.
+        username creator - the user that first saved the object to the
+            workspace.
+        ws_id orig_wsid - the id of the workspace in which this object was
+                originally saved. Missing for objects saved prior to version
+                0.4.1.
+        timestamp created - the date the object was first saved to the
+            workspace.
+        epoch epoch - the date the object was first saved to the
+            workspace.
+        list<obj_ref> - the references contained within the object.
+        obj_ref copied - the reference of the source object if this object is
+            a copy and the copy source exists and is accessible.
+            null otherwise.
+        boolean copy_source_inaccessible - true if the object was copied from
+            another object, but that object is no longer accessible to the
+            user. False otherwise.
+        mapping<id_type, list<extracted_id>> extracted_ids - any ids extracted
+            from the object.
+        string handle_error - if an error occurs while setting ACLs on
+            embedded handle IDs, it will be reported here.
+        string handle_stacktrace - the stacktrace for handle_error.
+        
+        @deprecated
+    */
+    typedef structure {
+        object_info info;
+        list<ProvenanceAction> provenance;
+        username creator;
+        ws_id orig_wsid;
+        timestamp created;
+        epoch epoch;
+        list<obj_ref> refs;
+        obj_ref copied;
+        boolean copy_source_inaccessible;
+        mapping<id_type, list<extracted_id>> extracted_ids;
+        string handle_error;
+        string handle_stacktrace;
+    } ObjectProvenanceInfo;
+    
+    /*  DEPRECATED
+        Get object provenance from the workspace.
+        
+        @deprecated Workspace.get_objects2
+    */
+    funcdef get_object_provenance(list<ObjectIdentity> object_ids)
+        returns (list<ObjectProvenanceInfo> data) authentication optional;
+    
+    /* The data and supplemental info for an object.
+    
+        UnspecifiedObject data - the object's data or subset data.
+        object_info info - information about the object.
+        list<ProvenanceAction> provenance - the object's provenance.
+        username creator - the user that first saved the object to the
+            workspace.
+        ws_id orig_wsid - the id of the workspace in which this object was
+                originally saved. Missing for objects saved prior to version
+                0.4.1.
+        timestamp created - the date the object was first saved to the
+            workspace.
+        epoch epoch - the date the object was first saved to the
+            workspace.
+        list<obj_ref> - the references contained within the object.
+        obj_ref copied - the reference of the source object if this object is
+            a copy and the copy source exists and is accessible.
+            null otherwise.
+        boolean copy_source_inaccessible - true if the object was copied from
+            another object, but that object is no longer accessible to the
+            user. False otherwise.
+        mapping<id_type, list<extracted_id>> extracted_ids - any ids extracted
+            from the object.
+        string handle_error - if an error occurs while setting ACLs on
+            embedded handle IDs, it will be reported here.
+        string handle_stacktrace - the stacktrace for handle_error.
+        
+    */
+    typedef structure {
+        UnspecifiedObject data;
+        object_info info;
+        list<ProvenanceAction> provenance;
+        username creator;
+        ws_id orig_wsid;
+        timestamp created;
+        epoch epoch;
+        list<obj_ref> refs;
+        obj_ref copied;
+        boolean copy_source_inaccessible;
+        mapping<id_type, list<extracted_id>> extracted_ids;
+        string handle_error;
+        string handle_stacktrace;
+    } ObjectData;
+    
+    /*  DEPRECATED
+        Get objects from the workspace.
+        @deprecated Workspace.get_objects2
+    */
+    funcdef get_objects(list<ObjectIdentity> object_ids)
+        returns (list<ObjectData> data) authentication optional;
+    
+    /* Input parameters for the get_objects2 function.
+    
+        Required parameters:
+        list<ObjectSpecification> objects - the list of object specifications
+            for the objects to return (via reference chain and as a subset if
+            specified).
+            
+        Optional parameters:
+        boolean ignoreErrors - Don't throw an exception if an object cannot
+            be accessed; return null for that object's information instead.
+            Default false.
+        boolean no_data - return the provenance, references, and
+            object_info for this object without the object data. Default false.
+    */
+    typedef structure {
+        list<ObjectSpecification> objects;
+        boolean ignoreErrors;
+        boolean no_data;
+    } GetObjects2Params;
+    
+    /* Results from the get_objects2 function.
+    
+        list<ObjectData> data - the returned objects.
+    */
+    typedef structure {
+        list<ObjectData> data;
+    } GetObjects2Results;
+    
+    /* Get objects from the workspace. */
+    funcdef get_objects2(GetObjects2Params params)
+        returns(GetObjects2Results results) authentication optional;
+    
+    /*  DEPRECATED
+        Get portions of objects from the workspace.
+        
+        When selecting a subset of an array in an object, the returned
+        array is compressed to the size of the subset, but the ordering of
+        the array is maintained. For example, if the array stored at the
+        'feature' key of a Genome object has 4000 entries, and the object paths
+        provided are:
+            /feature/7
+            /feature/3015
+            /feature/700
+        The returned feature array will be of length three and the entries will
+        consist, in order, of the 7th, 700th, and 3015th entries of the
+        original array.
+        @deprecated Workspace.get_objects2
+    */
+    funcdef get_object_subset(list<SubObjectIdentity> sub_object_ids)
+        returns (list<ObjectData> data) authentication optional;
+        
+    /* 
+        Get an object's history. The version argument of the ObjectIdentity is
+        ignored.
+    */
+    funcdef get_object_history(ObjectIdentity object)
+         returns (list<object_info> history) authentication optional;
+    
+    /* 
+        List objects that reference one or more specified objects. References
+        in the deleted state are not returned.
+    */
+    funcdef list_referencing_objects(list<ObjectIdentity> object_ids)
+        returns (list<list<object_info>> referrers) authentication optional;
+        
+    /*
+        DEPRECATED
+
+        List the number of times objects have been referenced.
+        
+        This count includes both provenance and object-to-object references
+        and, unlike list_referencing_objects, includes objects that are
+        inaccessible to the user.
+        
+        @deprecated
+    */
+    funcdef list_referencing_object_counts(list<ObjectIdentity> object_ids)
+        returns (list<int> counts) authentication optional;
+    
+    /*  DEPRECATED
+    
+        Get objects by references from other objects.
+    
+        NOTE: In the vast majority of cases, this method is not necessary and
+        get_objects should be used instead. 
+        
+        get_referenced_objects guarantees that a user that has access to an
+        object can always see a) objects that are referenced inside the object
+        and b) objects that are referenced in the object's provenance. This
+        ensures that the user has visibility into the entire provenance of the
+        object and the object's object dependencies (e.g. references).
+        
+        The user must have at least read access to the first object in each
+        reference chain, but need not have access to any further objects in
+        the chain, and those objects may be deleted.
+        
+        @deprecated Workspace.get_objects2
+    
+    */
+    funcdef get_referenced_objects(list<ref_chain> ref_chains)
+        returns (list<ObjectData> data) authentication optional;
+        
+    /* 
+        Input parameters for the "list_workspaces" function. Provided for
+        backwards compatibility.
+        
+        Optional parameters:
+        string auth - the authentication token of the KBase account accessing
+            the list of workspaces. Overrides the client provided authorization
+            credentials if they exist.
+        boolean excludeGlobal - if excludeGlobal is true exclude world
+            readable workspaces. Defaults to false.
+        
+        @deprecated Workspace.ListWorkspaceInfoParams
+    */
+    typedef structure { 
+        string auth;
+        boolean excludeGlobal;
+    } list_workspaces_params;
+    
+    /*
+        Lists the metadata of all workspaces a user has access to. Provided for
+        backwards compatibility - to be replaced by the functionality of
+        list_workspace_info
+        
+        @deprecated Workspace.list_workspace_info
+    */
+    funcdef list_workspaces(list_workspaces_params params)
+        returns (list<workspace_metadata> workspaces) authentication optional;
+    
+    /* 
+        Input parameters for the "list_workspace_info" function.
+        
+        Only one of each timestamp/epoch pair may be supplied.
+        
+        Optional parameters:
+        permission perm - filter workspaces by minimum permission level. 'None'
+            and 'readable' are ignored.
+        list<username> owners - filter workspaces by owner.
+        usermeta meta - filter workspaces by the user supplied metadata. NOTE:
+            only one key/value pair is supported at this time. A full map
+            is provided as input for the possibility for expansion in the
+            future.
+        timestamp after - only return workspaces that were modified after this
+            date.
+        timestamp before - only return workspaces that were modified before
+            this date.
+        epoch after_epoch - only return workspaces that were modified after
+            this date.
+        epoch before_epoch - only return workspaces that were modified before
+            this date.
+        boolean excludeGlobal - if excludeGlobal is true exclude world
+            readable workspaces. Defaults to false.
+        boolean showDeleted - show deleted workspaces that are owned by the
+            user.
+        boolean showOnlyDeleted - only show deleted workspaces that are owned
+            by the user.
+        
+    */
+    typedef structure { 
+        permission perm;
+        list<username> owners;
+        usermeta meta;
+        timestamp after;
+        timestamp before;
+        epoch after_epoch;
+        epoch before_epoch;
+        boolean excludeGlobal;
+        boolean showDeleted;
+        boolean showOnlyDeleted;
+    } ListWorkspaceInfoParams;
+    
+    /*
+        List workspaces viewable by the user.
+     */
+    funcdef list_workspace_info(ListWorkspaceInfoParams params)
+        returns(list<workspace_info> wsinfo) authentication optional;
+    
+    /* Input parameters for the "list_workspace_objects" function. Provided
+        for backwards compatibility.
+        
+        Required arguments:
+        ws_name workspace - Name of the workspace for which objects should be
+            listed
+        
+        Optional arguments:
+        type_string type - type of the objects to be listed. Here, omitting
+            version information will find any objects that match the provided
+            type - e.g. Foo.Bar-0 will match Foo.Bar-0.X where X is any
+            existing version.
+        boolean showDeletedObject - show objects that have been deleted
+        string auth - the authentication token of the KBase account requesting
+            access. Overrides the client provided authorization credentials if
+            they exist.
+            
+        @deprecated Workspace.ListObjectsParams
+    */
+    typedef structure { 
+       ws_name workspace;
+       type_string type;
+       boolean showDeletedObject;
+       string auth;
+    } list_workspace_objects_params;
+    
+    /*
+        Lists the metadata of all objects in the specified workspace with the
+        specified type (or with any type). Provided for backwards compatibility.
+        
+        @deprecated Workspace.list_objects
+    */
+    funcdef list_workspace_objects(list_workspace_objects_params params)
+        returns(list<object_metadata> objects) authentication optional;
+    
+    /* Parameters for the 'list_objects' function.
+
+        At least one of the following filters must be provided. It is strongly
+        recommended that the list is restricted to the workspaces of interest,
+        or the results may be very large:
+        list<ws_id> ids - the numerical IDs of the workspaces of interest.
+        list<ws_name> workspaces - names of the workspaces of interest or the
+            workspace IDs in KBase format, e.g. kb|ws.78.
+        type_string type - type of the objects to be listed.  Here, omitting
+            version information will find any objects that match the provided
+            type - e.g. Foo.Bar-0 will match Foo.Bar-0.X where X is any
+            existing version.
+        
+        Only one of each timestamp/epoch pair may be supplied.
+        
+        Optional arguments:
+        permission perm - filter objects by minimum permission level. 'None'
+            and 'readable' are ignored.
+        list<username> savedby - filter objects by the user that saved or
+            copied the object.
+        usermeta meta - filter objects by the user supplied metadata. NOTE:
+            only one key/value pair is supported at this time. A full map
+            is provided as input for the possibility for expansion in the
+            future.
+        timestamp after - only return objects that were created after this
+            date.
+        timestamp before - only return objects that were created before this
+            date.
+        epoch after_epoch - only return objects that were created after this
+            date.
+        epoch before_epoch - only return objects that were created before this
+            date.
+        obj_id minObjectID - only return objects with an object id greater or
+            equal to this value.
+        obj_id maxObjectID - only return objects with an object id less than or
+            equal to this value.
+        boolean showDeleted - show deleted objects in workspaces to which the
+            user has write access.
+        boolean showOnlyDeleted - only show deleted objects in workspaces to
+            which the user has write access.
+        boolean showHidden - show hidden objects.
+        boolean showAllVersions - show all versions of each object that match
+            the filters rather than only the most recent version.
+        boolean includeMetadata - include the user provided metadata in the
+            returned object_info. If false (0 or null), the default, the
+            metadata will be null.
+        boolean excludeGlobal - exclude objects in global workspaces. This
+            parameter only has an effect when filtering by types alone.
+        int limit - limit the output to X objects. Default and maximum value
+            is 10000. Limit values < 1 are treated as 10000, the default.
+        
+    */
+    typedef structure {
+        list<ws_name> workspaces;
+        list<ws_id> ids;
+        type_string type;
+        permission perm;
+        list<username> savedby;
+        usermeta meta;
+        timestamp after;
+        timestamp before;
+        epoch after_epoch;
+        epoch before_epoch;
+        obj_id minObjectID;
+        obj_id maxObjectID;
+        boolean showDeleted;
+        boolean showOnlyDeleted;
+        boolean showHidden;
+        boolean showAllVersions;
+        boolean includeMetadata;
+        boolean excludeGlobal;
+        int limit;
+    } ListObjectsParams;
+    
+    /*
+        List objects in one or more workspaces.
+    */
+    funcdef list_objects(ListObjectsParams params)
+        returns(list<object_info> objinfo) authentication optional;
+    
+    /* Input parameters for the "get_objectmeta" function.
+    
+        Required arguments:
+        ws_name workspace - name of the workspace containing the object for
+             which metadata is to be retrieved
+        obj_name id - name of the object for which metadata is to be retrieved
+        
+        Optional arguments:
+        int instance - Version of the object for which metadata is to be
+             retrieved, enabling retrieval of any previous version of an object
+        string auth - the authentication token of the KBase account requesting
+            access. Overrides the client provided authorization credentials if
+            they exist.
+            
+        @deprecated Workspace.ObjectIdentity
+    */
+    typedef structure { 
+        obj_name id;
+        ws_name workspace;
+        int instance;
+        string auth;
+    } get_objectmeta_params;
+    
+    /*
+        Retrieves the metadata for a specified object from the specified
+        workspace. Provides access to metadata for all versions of the object
+        via the instance parameter. Provided for backwards compatibility.
+        
+        @deprecated Workspace.get_object_info
+    */
+    funcdef get_objectmeta(get_objectmeta_params params) 
+        returns(object_metadata metadata) authentication optional; 
+    
+    /* 
+        Get information about objects from the workspace.
+        
+        Set includeMetadata true to include the user specified metadata.
+        Otherwise the metadata in the object_info will be null.
+        
+        This method will be replaced by the behavior of get_object_info_new
+        in the future.
+        
+        @deprecated Workspace.get_object_info_new
+    */
+    funcdef get_object_info(list<ObjectIdentity> object_ids,
+        boolean includeMetadata) returns (list<object_info> info)
+        authentication optional;
+    
+    /* Input parameters for the "get_object_info_new" function.
+    
+        Required arguments:
+        list<ObjectSpecification> objects - the objects for which the
+            information should be fetched. Subsetting related parameters are
+            ignored.
+        
+        Optional arguments:
+        boolean includeMetadata - include the object metadata in the returned
+            information. Default false.
+        boolean ignoreErrors - Don't throw an exception if an object cannot
+            be accessed; return null for that object's information instead.
+            Default false.
+            
+    */
+    typedef structure { 
+        list<ObjectSpecification> objects;
+        boolean includeMetadata;
+        boolean ignoreErrors;
+    } GetObjectInfoNewParams;
+    
+    /* 
+        Get information about objects from the workspace.
+        
+    */
+    funcdef get_object_info_new(GetObjectInfoNewParams params)
+        returns (list<object_info> info) authentication optional;
+    
+    /* Input parameters for the 'rename_workspace' function.
+        
+        Required arguments:
+        WorkspaceIdentity wsi - the workspace to rename.
+        ws_name new_name - the new name for the workspace.
+    */
+    typedef structure {
+        WorkspaceIdentity wsi;
+        ws_name new_name;
+    } RenameWorkspaceParams;
+    
+    /* 
+        Rename a workspace.
+    */
+    funcdef rename_workspace(RenameWorkspaceParams params)
+        returns(workspace_info renamed) authentication required;
+    
+    /* Input parameters for the 'rename_object' function.
+        
+        Required arguments:
+        ObjectIdentity obj - the object to rename.
+        obj_name new_name - the new name for the object.
+    */
+    typedef structure {
+        ObjectIdentity obj;
+        obj_name new_name;
+    } RenameObjectParams;
+    
+    /* 
+        Rename an object. User meta data is always returned as null.
+    */
+    funcdef rename_object(RenameObjectParams params)
+        returns(object_info renamed) authentication required;
+        
+    /* Input parameters for the 'copy_object' function. 
+    
+        If the 'from' ObjectIdentity includes no version and the object is
+        copied to a new name, the entire version history of the object is
+        copied. In all other cases only the version specified, or the latest
+        version if no version is specified, is copied.
+        
+        The version from the 'to' ObjectIdentity is always ignored.
+        
+        Required arguments:
+        ObjectIdentity from - the object to copy.
+        ObjectIdentity to - where to copy the object.
+    */
+    typedef structure {
+        ObjectIdentity from;
+        ObjectIdentity to;
+    } CopyObjectParams;
+    
+    /* 
+        Copy an object. Returns the object_info for the newest version.
+    */
+    funcdef copy_object(CopyObjectParams params)
+        returns(object_info copied) authentication required;
+    
+    /* Revert an object.
+    
+        The object specified in the ObjectIdentity is reverted to the version
+        specified in the ObjectIdentity. 
+    */
+    funcdef revert_object(ObjectIdentity object)
+        returns(object_info reverted) authentication required;
+    
+    /* Input parameters for the get_names_by_prefix function.
+    
+        Required arguments:
+        list<WorkspaceIdentity> workspaces - the workspaces to search.
+        string prefix - the prefix of the object names to return.
+        
+        Optional arguments:
+        boolean includeHidden - include names of hidden objects in the results.
+            Default false.
+    */
+    typedef structure {
+        list<WorkspaceIdentity> workspaces;
+        string prefix;
+        boolean includeHidden;
+    } GetNamesByPrefixParams;
+    
+    /* Results object for the get_names_by_prefix function.
+    
+        list<list<obj_name>> names - the names matching the provided prefix,
+            listed in order of the input workspaces.
+    */
+    typedef structure {
+        list<list<obj_name>> names;
+    } GetNamesByPrefixResults;
+    
+    /*
+        Get object names matching a prefix. At most 1000 names are returned.
+        No particular ordering is guaranteed, nor is which names will be
+        returned if more than 1000 are found.
+        
+        This function is intended for use as an autocomplete helper function.
+    */
+    funcdef get_names_by_prefix(GetNamesByPrefixParams params)
+        returns(GetNamesByPrefixResults res) authentication optional;
+    
+    /* 
+        Hide objects. All versions of an object are hidden, regardless of
+        the version specified in the ObjectIdentity. Hidden objects do not
+        appear in the list_objects method.
+    */
+    funcdef hide_objects(list<ObjectIdentity> object_ids) returns()
+        authentication required;
+    
+    /* 
+        Unhide objects. All versions of an object are unhidden, regardless
+        of the version specified in the ObjectIdentity.
+    */
+    funcdef unhide_objects(list<ObjectIdentity> object_ids) returns()
+        authentication required;
+    
+    /* 
+        Delete objects. All versions of an object are deleted, regardless of
+        the version specified in the ObjectIdentity.
+    */
+    funcdef delete_objects(list<ObjectIdentity> object_ids) returns()
+        authentication required;
+    
+    /* 
+        Undelete objects. All versions of an object are undeleted, regardless
+        of the version specified in the ObjectIdentity. If an object is not
+        deleted, no error is thrown.
+    */
+    funcdef undelete_objects(list<ObjectIdentity> object_ids) returns()
+        authentication required;
+    
+    /*
+        Delete a workspace. All objects contained in the workspace are deleted.
+    */
+    funcdef delete_workspace(WorkspaceIdentity wsi) returns()
+        authentication required;
+    
+    /* 
+        Undelete a workspace. All objects contained in the workspace are
+        undeleted, regardless of their state at the time the workspace was
+        deleted.
+    */
+    funcdef undelete_workspace(WorkspaceIdentity wsi) returns()
+        authentication required;
+    
+    /* **************** Type registering functions ******************** */
+    
+    /* A type specification (typespec) file in the KBase Interface Description
+        Language (KIDL).
+    */
+    typedef string typespec;
+     
+    /* A module name defined in a KIDL typespec. */
+    typedef string modulename;
+    
+    /* A type definition name in a KIDL typespec. */
+    typedef string typename;
+    
+    /* A version of a type. 
+        Specifies the version of the type  in a single string in the format
+        [major].[minor]:
+        
+        major - an integer. The major version of the type. A change in the
+            major version implies the type has changed in a non-backwards
+            compatible way.
+        minor - an integer. The minor version of the type. A change in the
+            minor version implies that the type has changed in a way that is
+            backwards compatible with previous type definitions.
+    */
+    typedef string typever;
+
+    /* A function string for referencing a funcdef.
+        Specifies the function and its version in a single string in the format
+        [modulename].[funcname]-[major].[minor]:
+        
+        modulename - a string. The name of the module containing the function.
+        funcname - a string. The name of the function as assigned by the funcdef
+            statement.
+        major - an integer. The major version of the function. A change in the
+            major version implies the function has changed in a non-backwards
+            compatible way.
+        minor - an integer. The minor version of the function. A change in the
+            minor version implies that the function has changed in a way that is
+            backwards compatible with previous function definitions.
+        
+        In many cases, the major and minor versions are optional, and if not
+        provided the most recent version will be used.
+        
+        Example: MyModule.MyFunc-3.1
+    */
+    typedef string func_string;
+    
+    /* The version of a typespec file. */
+    typedef int spec_version;
+    
+    /* The JSON Schema (v4) representation of a type definition. */
+    typedef string jsonschema;
+    
+    /* Request ownership of a module name. A Workspace administrator
+        must approve the request.
+    */
+    funcdef request_module_ownership(modulename mod) returns()
+        authentication required;
+    
+    /* Parameters for the register_typespec function.
+    
+        Required arguments:
+        One of:
+        typespec spec - the new typespec to register.
+        modulename mod - the module to recompile with updated options (see below).
+        
+        Optional arguments:
+        boolean dryrun - Return, but do not save, the results of compiling the 
+            spec. Default true. Set to false for making permanent changes.
+        list<typename> new_types - types in the spec to make available in the
+            workspace service. When compiling a spec for the first time, if
+            this argument is empty no types will be made available. Previously
+            available types remain so upon recompilation of a spec or
+            compilation of a new spec.
+        list<typename> remove_types - no longer make these types available in
+            the workspace service for the new version of the spec. This does
+            not remove versions of types previously compiled.
+        mapping<modulename, spec_version> dependencies - By default, the
+            latest released versions of spec dependencies will be included when
+            compiling a spec. Specific versions can be specified here.
+        spec_version prev_ver - the id of the previous version of the typespec.
+            An error will be thrown if this is set and prev_ver is not the
+            most recent version of the typespec. This prevents overwriting of
+            changes made since retrieving a spec and compiling an edited spec.
+            This argument is ignored if a modulename is passed.
+    */
+    typedef structure {
+        typespec spec;
+        modulename mod;
+        list<typename> new_types;
+        list<typename> remove_types;
+        mapping<modulename, spec_version> dependencies;
+        boolean dryrun;
+        spec_version prev_ver;
+    } RegisterTypespecParams;
+    
+    /* Register a new typespec or recompile a previously registered typespec
+        with new options.
+        See the documentation of RegisterTypespecParams for more details.
+        Also see the release_types function.
+    */
+    funcdef register_typespec(RegisterTypespecParams params)
+        returns (mapping<type_string,jsonschema>) authentication required;
+    
+    /* Parameters for the register_typespec_copy function.
+    
+        Required arguments:
+        string external_workspace_url - the URL of the  workspace server from
+            which to copy a typespec.
+        modulename mod - the name of the module in the workspace server
+        
+        Optional arguments:
+        spec_version version - the version of the module in the workspace
+            server
+
+    */
+    typedef structure {
+        string external_workspace_url;
+        modulename mod;
+        spec_version version;
+    } RegisterTypespecCopyParams;
+    
+    /* Register a copy of new typespec or refresh an existing typespec which is
+        loaded from another workspace for synchronization. Method returns new
+        version of module in current workspace.
+        
+        Also see the release_types function.
+    */
+    funcdef register_typespec_copy(RegisterTypespecCopyParams params)
+        returns(spec_version new_local_version) authentication required;
+    
+    /* Release a module for general use of its types.
+        
+        Releases the most recent version of a module. Releasing a module does
+        two things to the module's types:
+        1) If a type's major version is 0, it is changed to 1. A major
+            version of 0 implies that the type is in development and may have
+            backwards incompatible changes from minor version to minor version.
+            Once a type is released, backwards incompatible changes always
+            cause a major version increment.
+        2) This version of the type becomes the default version, and if a 
+            specific version is not supplied in a function call, this version
+            will be used. This means that newer, unreleased versions of the
+            type may be skipped.
+    */
+    funcdef release_module(modulename mod) returns(list<type_string> types)
+        authentication required;
+    
+    /* Parameters for the list_modules() function.
+    
+        Optional arguments:
+        username owner - only list modules owned by this user.
+    */
+    typedef structure {
+        username owner;
+    } ListModulesParams;
+    
+    /* List typespec modules. */
+    funcdef list_modules(ListModulesParams params)
+        returns(list<modulename> modules) authentication none;
+    
+    /* Parameters for the list_module_versions function.
+    
+        Required arguments:
+        One of:
+        modulename mod - returns all versions of the module.
+        type_string type - returns all versions of the module associated with
+            the type.
+    */
+    typedef structure {
+        modulename mod;
+        type_string type;
+    } ListModuleVersionsParams;
+    
+    /* A set of versions from a module.
+    
+        modulename mod - the name of the module.
+        list<spec_version> - a set or subset of versions associated with the
+            module.
+        list<spec_version> - a set or subset of released versions associated 
+            with the module.
+    */
+    typedef structure {
+        modulename mod;
+        list<spec_version> vers;
+        list<spec_version> released_vers;
+    } ModuleVersions;
+    
+    /* List typespec module versions. */
+    funcdef list_module_versions(ListModuleVersionsParams params)
+         returns(ModuleVersions vers) authentication optional;
+    
+    /* Parameters for the get_module_info function.
+    
+        Required arguments:
+        modulename mod - the name of the module to retrieve.
+        
+        Optional arguments:
+        spec_version ver - the version of the module to retrieve. Defaults to
+            the latest version.
+    */
+    typedef structure {
+        modulename mod;
+        spec_version ver;
+    } GetModuleInfoParams;
+    
+    /* Information about a module.
+    
+        list<username> owners - the owners of the module.
+        spec_version ver - the version of the module.
+        typespec spec - the typespec.
+        string description - the description of the module from the typespec.
+        mapping<type_string, jsonschema> types - the types associated with this
+            module and their JSON schema.
+        mapping<modulename, spec_version> included_spec_version - names of 
+            included modules associated with their versions.
+        string chsum - the md5 checksum of the object.
+        list<func_string> functions - list of names of functions registered in spec.
+        boolean is_released - shows if this version of module was released (and
+            hence can be seen by others).
+    */
+    typedef structure {
+        list<username> owners;
+        spec_version ver;
+        typespec spec;
+        string description;
+        mapping<type_string, jsonschema> types;
+        mapping<modulename, spec_version> included_spec_version;
+        string chsum;
+        list<func_string> functions;
+        boolean is_released;
+    } ModuleInfo;
+    
+    funcdef get_module_info(GetModuleInfoParams params)
+        returns(ModuleInfo info) authentication optional;
+        
+    /* Get JSON schema for a type. */
+    funcdef get_jsonschema(type_string type) returns(jsonschema schema)
+        authentication optional;
+
+    /* Translation from types qualified with MD5 to their semantic versions */
+    funcdef translate_from_MD5_types(list<type_string> md5_types) 
+        returns(mapping<type_string, list<type_string>> sem_types)
+        authentication none;
+
+    /* Translation from types qualified with semantic versions to their MD5'ed versions */
+    funcdef translate_to_MD5_types(list<type_string> sem_types) 
+        returns(mapping<type_string, type_string> md5_types)
+        authentication optional;
+
+    /* Information about a type
+    
+        type_string type_def - resolved type definition id.
+        string description - the description of the type from spec file.
+        string spec_def - reconstruction of type definition from spec file.
+        jsonschema json_schema - JSON schema of this type.
+        string parsing_structure - json document describing parsing structure of type 
+            in spec file including involved sub-types.
+        list<spec_version> module_vers - versions of spec-files containing
+            given type version.
+        list<spec_version> released_module_vers - versions of released spec-files 
+            containing given type version.
+        list<type_string> type_vers - all versions of type with given type name.
+        list<type_string> released_type_vers - all released versions of type with 
+            given type name.
+        list<func_string> using_func_defs - list of functions (with versions)
+            referring to this type version.
+        list<type_string> using_type_defs - list of types (with versions)
+            referring to this type version.
+        list<type_string> used_type_defs - list of types (with versions) 
+            referred from this type version.
+    */
+    typedef structure {
+        type_string type_def;
+        string description;
+        string spec_def;
+        jsonschema json_schema;
+        string parsing_structure;
+        list<spec_version> module_vers;
+        list<spec_version> released_module_vers;
+        list<type_string> type_vers;
+        list<type_string> released_type_vers;
+        list<func_string> using_func_defs;
+        list<type_string> using_type_defs;
+        list<type_string> used_type_defs;
+    } TypeInfo;
+    
+    funcdef get_type_info(type_string type) returns(TypeInfo info)
+        authentication optional;
+    
+    funcdef get_all_type_info(modulename mod) returns(list<TypeInfo>)
+        authentication optional;
+    
+    /* Information about a function
+    
+        func_string func_def - resolved func definition id.
+        string description - the description of the function from spec file.
+        string spec_def - reconstruction of function definition from spec file.
+        string parsing_structure - json document describing parsing structure of function 
+            in spec file including types of arguments.
+        list<spec_version> module_vers - versions of spec files containing
+            given func version.
+        list<spec_version> released_module_vers - released versions of spec files 
+            containing given func version.
+        list<func_string> func_vers - all versions of function with given type
+            name.
+        list<func_string> released_func_vers - all released versions of function 
+            with given type name.
+        list<type_string> used_type_defs - list of types (with versions) 
+            referred to from this function version.
+    */
+    typedef structure {
+        func_string func_def;
+        string description;
+        string spec_def;
+        string parsing_structure;
+        list<spec_version> module_vers;
+        list<spec_version> released_module_vers;
+        list<func_string> func_vers;
+        list<func_string> released_func_vers;
+        list<type_string> used_type_defs;
+    } FuncInfo;
+    
+    funcdef get_func_info(func_string func) returns(FuncInfo info)
+        authentication optional;
+    
+    funcdef get_all_func_info(modulename mod) returns(list<FuncInfo> info)
+        authentication optional;
+    
+    /* Parameters for the grant_module_ownership function.
+        
+        Required arguments:
+        modulename mod - the module to modify.
+        username new_owner - the user to add to the module's list of
+            owners.
+        
+        Optional arguments:
+        boolean with_grant_option - true to allow the user to add owners
+            to the module.
+    */
+    typedef structure {
+        modulename mod;
+        username new_owner;
+        boolean with_grant_option;
+    } GrantModuleOwnershipParams;
+    
+    /* Grant ownership of a module. You must have grant ability on the
+        module.
+    */
+    funcdef grant_module_ownership(GrantModuleOwnershipParams params) 
+        returns() authentication required;
+    
+    /* Parameters for the remove_module_ownership function.
+        
+        Required arguments:
+        modulename mod - the module to modify.
+        username old_owner - the user to remove from the module's list of
+            owners.
+    */
+    typedef structure {
+        modulename mod;
+        username old_owner;
+    } RemoveModuleOwnershipParams;
+    
+    /* Remove ownership from a current owner. You must have the grant ability
+        on the module.
+    */
+    funcdef remove_module_ownership(RemoveModuleOwnershipParams params) 
+        returns() authentication required;
+    
+    /* Parameters for list_all_types function.
+        
+        Optional arguments:
+        boolean with_empty_modules - include empty module names, optional flag,
+            default value is false.
+    */
+    typedef structure {
+        boolean with_empty_modules;
+    } ListAllTypesParams;
+    
+    /* List all released types with released version from all modules. Return
+        mapping from module name to mapping from type name to released type
+        version.
+    */
+    funcdef list_all_types(ListAllTypesParams params)
+        returns (mapping<modulename, mapping<typename, typever>>)
+        authentication optional;
+    
+    /* The administration interface. */
+    funcdef administer(UnspecifiedObject command)
+        returns(UnspecifiedObject response) authentication required;
+};


### PR DESCRIPTION
Includes ability to get subsets of the object in a genome-specific way (so it will be easier to update as the underlying type changes).

Interface for saving legacy data was added, but not yet implemented.
