### PR TITLE
SCT-465: Genome save back-compatibility 

### DIFF
--- a/GenomeAnnotationAPI.spec
+++ b/GenomeAnnotationAPI.spec
@@ -709,6 +709,9 @@ module GenomeAnnotationAPI {
     typedef structure {
         Workspace.object_info info;
     } SaveGenomeResultV1;
+    /*
+        @deprecated: GenomeFileUtil.save_one_genome
+    */
 
     funcdef save_one_genome_v1(SaveOneGenomeParamsV1 params)
                 returns (SaveGenomeResultV1 result) authentication required;

--- a/kbase.yml
+++ b/kbase.yml
@@ -8,7 +8,7 @@ service-language:
     python
 
 module-version:
-    0.3.0
+    0.3.1
 
 owners:
     [scanon,mhenderson,msneddon,rsutormin,umaganapathyswork,jjeffryes]

--- a/lib/GenomeAnnotationAPI/GenomeAnnotationAPIClient.pm
+++ b/lib/GenomeAnnotationAPI/GenomeAnnotationAPIClient.pm
@@ -3808,7 +3808,7 @@ usermeta is a reference to a hash where the key is a string and the value is a s
 
 =item Description
 
-
+@deprecated: GenomeFileUtil.save_one_genome
 
 =back
 

--- a/lib/GenomeAnnotationAPI/GenomeAnnotationAPIClient.py
+++ b/lib/GenomeAnnotationAPI/GenomeAnnotationAPIClient.py
@@ -875,6 +875,7 @@ class GenomeAnnotationAPI(object):
 
     def save_one_genome_v1(self, params, context=None):
         """
+        @deprecated: GenomeFileUtil.save_one_genome
         :param params: instance of type "SaveOneGenomeParamsV1" -> structure:
            parameter "workspace" of String, parameter "name" of String,
            parameter "data" of type "Genome" (Genome object holds much of the

--- a/lib/GenomeAnnotationAPI/GenomeAnnotationAPIImpl.py
+++ b/lib/GenomeAnnotationAPI/GenomeAnnotationAPIImpl.py
@@ -27,7 +27,7 @@ class GenomeAnnotationAPI:
     ######################################### noqa
     VERSION = "0.3.0"
     GIT_URL = "git@github.com:kbase/genome_annotation_api.git"
-    GIT_COMMIT_HASH = "f67d18f16e6a1b39476ff0e1a67938dd9db08bbd"
+    GIT_COMMIT_HASH = "737ba428e1da7cae290ba9ebdda274ddef83f0b7"
 
     #BEGIN_CLASS_HEADER
     def _migrate_property_internal(self, from_dict, to_dict, prop_name, to_prop_name = None):
@@ -1424,6 +1424,7 @@ class GenomeAnnotationAPI:
 
     def save_one_genome_v1(self, ctx, params):
         """
+        @deprecated: GenomeFileUtil.save_one_genome
         :param params: instance of type "SaveOneGenomeParamsV1" -> structure:
            parameter "workspace" of String, parameter "name" of String,
            parameter "data" of type "Genome" (Genome object holds much of the

--- a/lib/GenomeAnnotationAPI/GenomeInterfaceV1.py
+++ b/lib/GenomeAnnotationAPI/GenomeInterfaceV1.py
@@ -200,6 +200,7 @@ class GenomeInterfaceV1:
 
     def save_one_genome(self, ctx, params):
         """
+        DEPRICATED: use GenomeFileUtil.save_one_genome
         typedef structure {
             string workspace;
             string name;
@@ -272,11 +273,16 @@ class GenomeInterfaceV1:
                     except:
                         raise TypeError('Invalid closeness_measure value "{}": float expected'
                                         .format(closeness_measure))
+
+        # pegging this API to a specific, old version of the genome
+        old_genome_type = self.ws.translate_from_MD5_types(
+            ['KBaseGenomes.Genome-f6e83df5424e9e67c6185f1d21e07b50']).values()[0][0]
+
         save_params = {
             'objects': [{
                 'name': name,
                 'data': data,
-                'type': 'KBaseGenomes.Genome',
+                'type': old_genome_type,
                 'provenance': provenance,
                 'hidden': hidden
             }]

--- a/lib/src/us/kbase/genomeannotationapi/GenomeAnnotationAPIClient.java
+++ b/lib/src/us/kbase/genomeannotationapi/GenomeAnnotationAPIClient.java
@@ -617,6 +617,7 @@ public class GenomeAnnotationAPIClient {
     /**
      * <p>Original spec-file function name: save_one_genome_v1</p>
      * <pre>
+     * @deprecated: GenomeFileUtil.save_one_genome
      * </pre>
      * @param   params   instance of type {@link us.kbase.genomeannotationapi.SaveOneGenomeParamsV1 SaveOneGenomeParamsV1}
      * @return   parameter "result" of type {@link us.kbase.genomeannotationapi.SaveGenomeResultV1 SaveGenomeResultV1}


### PR DESCRIPTION
Per discussion with Gavin: old apps that use API should not break if we can avoid it. Add depreciation warning to save_genome_v1. Use MD5 to ensure that save_genome_v1 saves as old genome style.